### PR TITLE
Mike reference manual

### DIFF
--- a/docs/reference/kumo/index.markdown
+++ b/docs/reference/kumo/index.markdown
@@ -1,7 +1,0 @@
-# `require 'kumo'`
-
-The `kumo` module provides access to the core KumoMTA functions used to express
-your configuration and policy.
-
-
-


### PR DESCRIPTION
Getting rid of the reference for a shell variable, we don't need it.