### PR TITLE
Add method remove_all_named_header in lua

### DIFF
--- a/crates/message/src/message.rs
+++ b/crates/message/src/message.rs
@@ -665,7 +665,7 @@ impl Message {
         })
     }
 
-    pub fn remove_all_named_header(&self, name: &str) -> anyhow::Result<()> {
+    pub fn remove_all_named_headers(&self, name: &str) -> anyhow::Result<()> {
         self.retain_headers(|hdr| !hdr.get_key_ref().eq_ignore_ascii_case(name))
     }
 
@@ -684,7 +684,7 @@ impl Message {
             self.set_scheduling(Some(sched))?;
 
             if remove {
-                self.remove_all_named_header(header_name)?;
+                self.remove_all_named_headers(header_name)?;
             }
         }
 
@@ -827,8 +827,8 @@ impl UserData for Message {
                     .map_err(any_err)?)
             },
         );
-        methods.add_method("remove_all_named_header", move |_, this, name: String| {
-            Ok(this.remove_all_named_header(&name).map_err(any_err)?)
+        methods.add_method("remove_all_named_headers", move |_, this, name: String| {
+            Ok(this.remove_all_named_headers(&name).map_err(any_err)?)
         });
 
         methods.add_method(
@@ -1088,7 +1088,7 @@ mod test {
     #[test]
     fn remove_all() {
         let msg = new_msg_body(MULTI_HEADER_CONTENT);
-        msg.remove_all_named_header("X-header").unwrap();
+        msg.remove_all_named_headers("X-header").unwrap();
         k9::assert_equal!(
             data_as_string(&msg),
             "X-Hello: there\r\nSubject: Hello\r\nFrom : Someone\r\n\r\nBody"

--- a/crates/message/src/message.rs
+++ b/crates/message/src/message.rs
@@ -827,6 +827,12 @@ impl UserData for Message {
                     .map_err(any_err)?)
             },
         );
+        methods.add_method(
+            "remove_all_named_header",
+            move |_, this, name: String| {
+                Ok(this.remove_all_named_header(&name).map_err(any_err)?)
+            },
+        );
 
         methods.add_method(
             "import_scheduling_header",

--- a/crates/message/src/message.rs
+++ b/crates/message/src/message.rs
@@ -827,12 +827,9 @@ impl UserData for Message {
                     .map_err(any_err)?)
             },
         );
-        methods.add_method(
-            "remove_all_named_header",
-            move |_, this, name: String| {
-                Ok(this.remove_all_named_header(&name).map_err(any_err)?)
-            },
-        );
+        methods.add_method("remove_all_named_header", move |_, this, name: String| {
+            Ok(this.remove_all_named_header(&name).map_err(any_err)?)
+        });
 
         methods.add_method(
             "import_scheduling_header",

--- a/docs/reference/message/remove_all_named_headers.md
+++ b/docs/reference/message/remove_all_named_headers.md
@@ -1,0 +1,5 @@
+# `message:remove_all_named_headers(NAME)`
+{{since('dev')}}
+
+Removes all header fields with name `NAME` from the message header.
+


### PR DESCRIPTION
To support removal of any header the remove_all_named_header is exported in Lua. This can be used to remove bogus headers added by internal applications, for example Return-Path. 