### PR TITLE
add mx_list_ip_map to smtp protocole for tls connection

### DIFF
--- a/assets/policy-extras/rollup.lua
+++ b/assets/policy-extras/rollup.lua
@@ -41,7 +41,7 @@ local function compute_ip_rollup_mx_list(domain, routing_domain)
     -- and hash consistently with the resulting ready queue name
     table.sort(host_addrs)
     for _, a in ipairs(host_addrs) do
-      table.insert(addrs, { ['name'] = host, ['addr'] = a })
+      table.insert(addrs, { name = host, addr = a })
     end
   end
 

--- a/assets/policy-extras/rollup.lua
+++ b/assets/policy-extras/rollup.lua
@@ -33,7 +33,6 @@ local function compute_ip_rollup_mx_list(domain, routing_domain)
   end
 
   local addrs = {}
-  local addrs_map = {}
   -- The host names are pre-sorted by lookup_mx
   for _, host in ipairs(hosts) do
     local host_addrs = kumo.dns.lookup_addr(host)
@@ -42,23 +41,19 @@ local function compute_ip_rollup_mx_list(domain, routing_domain)
     -- and hash consistently with the resulting ready queue name
     table.sort(host_addrs)
     for _, a in ipairs(host_addrs) do
-      local ip = string.format('[%s]', a)
-      table.insert(addrs, ip)
-      addrs_map[ip] = host
+      table.insert(addrs, { ['name'] = host, ['addr'] = a })
     end
   end
 
-  return addrs, addrs_map
+  return addrs
 end
 
 function mod.apply_ip_rollup_to_queue_config(domain, routing_domain, params)
-  local mx_list, mx_list_ip_map =
-    compute_ip_rollup_mx_list(domain, routing_domain)
+  local mx_list = compute_ip_rollup_mx_list(domain, routing_domain)
   if mx_list then
     params.protocol = {
       smtp = {
         mx_list = mx_list,
-        mx_list_ip_map = mx_list_ip_map,
       },
     }
   end

--- a/crates/kumod/src/smtp_dispatcher.rs
+++ b/crates/kumod/src/smtp_dispatcher.rs
@@ -23,10 +23,10 @@ pub struct SmtpProtocol {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum MxListEntry {
-    // A name that needs to be resolved to its A or AAAA record in DNS,
-    // or an IP domain literal enclosed in square brackets like `[10.0.0.1]`
+    /// A name that needs to be resolved to its A or AAAA record in DNS,
+    /// or an IP domain literal enclosed in square brackets like `[10.0.0.1]`
     Name(String),
-    // A pre-resolved name and IP address
+    /// A pre-resolved name and IP address
     Resolved(ResolvedAddress),
 }
 

--- a/docs/reference/kumo/make_queue_config.md
+++ b/docs/reference/kumo/make_queue_config.md
@@ -84,7 +84,7 @@ kumo.on('get_queue_config', function(domain, tenant, campaign)
   end
   -- Otherwise, just use the defaults
   return kumo.make_queue_config {}
-en)
+end)
 ```
 
 ### Example of using the Maildir protocol

--- a/docs/reference/kumo/make_queue_config.md
+++ b/docs/reference/kumo/make_queue_config.md
@@ -77,7 +77,7 @@ kumo.on('get_queue_config', function(domain, tenant, campaign)
     return kumo.make_queue_config {
       protocol = {
         smtp = {
-            mx_list = { 'smart.host.local', {name="mx.example.com", addr='10.0.0.1'} }
+            mx_list = { 'smart.host.local', { name = 'mx.example.com', addr = '10.0.0.1' }}
         },
       },
     }

--- a/docs/reference/kumo/make_queue_config.md
+++ b/docs/reference/kumo/make_queue_config.md
@@ -77,7 +77,10 @@ kumo.on('get_queue_config', function(domain, tenant, campaign)
     return kumo.make_queue_config {
       protocol = {
         smtp = {
-          mx_list = { 'smart.host.local', { name = 'mx.example.com', addr = '10.0.0.1' }}
+          mx_list = {
+            'smart.host.local',
+            { name = 'mx.example.com', addr = '10.0.0.1' },
+          },
         },
       },
     }

--- a/docs/reference/kumo/make_queue_config.md
+++ b/docs/reference/kumo/make_queue_config.md
@@ -77,7 +77,7 @@ kumo.on('get_queue_config', function(domain, tenant, campaign)
     return kumo.make_queue_config {
       protocol = {
         smtp = {
-          mx_list = { 'smart.host.local', '[10.0.0.1]' },
+            mx_list = { 'smart.host.local', {name="mx.example.com", addr='10.0.0.1'} }
         },
       },
     }

--- a/docs/reference/kumo/make_queue_config.md
+++ b/docs/reference/kumo/make_queue_config.md
@@ -77,14 +77,14 @@ kumo.on('get_queue_config', function(domain, tenant, campaign)
     return kumo.make_queue_config {
       protocol = {
         smtp = {
-            mx_list = { 'smart.host.local', { name = 'mx.example.com', addr = '10.0.0.1' }}
+          mx_list = { 'smart.host.local', { name = 'mx.example.com', addr = '10.0.0.1' }}
         },
       },
     }
   end
   -- Otherwise, just use the defaults
   return kumo.make_queue_config {}
-end)
+en)
 ```
 
 ### Example of using the Maildir protocol

--- a/docs/userguide/policy/routing.md
+++ b/docs/userguide/policy/routing.md
@@ -54,10 +54,7 @@ several options.
             return kumo.make_queue_config {
                 protocol = {
                     smtp = {
-                        mx_list = { 'smart.host.local', '[10.0.0.1]' },
-                        mx_list_ip_map = {
-                            ['[10.0.0.1]'] = 'mx.example.com.'
-                            }
+                        mx_list = { 'smart.host.local', {name="mx.example.com", addr='10.0.0.1'} }
                     },
                 },
             }
@@ -71,7 +68,7 @@ several options.
     the list of hosts in `mx_list`.  `mx_list` is used as the ordered list
     of hosts to which the message should be delivered.  It is used in
     place of the normal MX resolution that would have been carried out
-    for the domain. 'mx_list_ip_map' maps ips from mx_list to their domain for tls connection. If left empty, enable_tls needs to be "OpportunisticInsecure" or "Disabled".
+    for the domain.
 
     With this approach, the original scheduled queue name remains as it
     was.

--- a/docs/userguide/policy/routing.md
+++ b/docs/userguide/policy/routing.md
@@ -54,7 +54,7 @@ several options.
             return kumo.make_queue_config {
                 protocol = {
                     smtp = {
-                        mx_list = { 'smart.host.local', {name="mx.example.com", addr='10.0.0.1'} }
+                        mx_list = { 'smart.host.local', {name='mx.example.com', addr='10.0.0.1'} }
                     },
                 },
             }

--- a/docs/userguide/policy/routing.md
+++ b/docs/userguide/policy/routing.md
@@ -54,7 +54,7 @@ several options.
             return kumo.make_queue_config {
                 protocol = {
                     smtp = {
-                        mx_list = { 'smart.host.local', {name='mx.example.com', addr='10.0.0.1'} }
+                        mx_list = { 'smart.host.local', { name = 'mx.example.com', addr = '10.0.0.1' }}
                     },
                 },
             }

--- a/docs/userguide/policy/routing.md
+++ b/docs/userguide/policy/routing.md
@@ -55,6 +55,9 @@ several options.
                 protocol = {
                     smtp = {
                         mx_list = { 'smart.host.local', '[10.0.0.1]' },
+                        mx_list_ip_map = {
+                            ['[10.0.0.1]'] = 'mx.example.com.'
+                            }
                     },
                 },
             }
@@ -68,7 +71,7 @@ several options.
     the list of hosts in `mx_list`.  `mx_list` is used as the ordered list
     of hosts to which the message should be delivered.  It is used in
     place of the normal MX resolution that would have been carried out
-    for the domain.
+    for the domain. 'mx_list_ip_map' maps ips from mx_list to their domain for tls connection. If left empty, enable_tls needs to be "OpportunisticInsecure" or "Disabled".
 
     With this approach, the original scheduled queue name remains as it
     was.


### PR DESCRIPTION
add a hashmap of ip, domains to have the canonical name for tls connection and avoid the error: rust invalid peer certificate: NotValidForName when enable_tls is not "Disabled" or "OpportunisticInsecure"