### PR TITLE
use logRecord reception_protocol to avoid loop

### DIFF
--- a/assets/policy-extras/log_hooks.lua
+++ b/assets/policy-extras/log_hooks.lua
@@ -73,10 +73,7 @@ function mod:new(options)
     local log_record = msg:get_meta 'log_record'
 
     -- avoid an infinite loop caused by logging that we logged that we logged...
-    -- Check the log record: if the record was destined for the webhook queue
-    -- then it was a record of the webhook delivery attempt and we must not
-    -- log its outcome via the webhook.
-    if log_record.queue == domain_name then
+    if log_record.reception_protocol == 'LogRecord' then
       return false
     end
 

--- a/assets/policy-extras/shaping.lua
+++ b/assets/policy-extras/shaping.lua
@@ -60,6 +60,10 @@ local function should_enq(publish, msg, hook_name)
   end
 
   local log_record = msg:get_meta 'log_record'
+  -- avoid overlap with other logs
+  if log_record.reception_protocol == 'LogRecord' then
+    return false
+  end
 
   -- We only want to log if the event isn't one of our
   -- publishing events


### PR DESCRIPTION
Don't queue if reception_protocol == 'LogRecord'