### PR TITLE
only add meta to log if not null

### DIFF
--- a/crates/kumod/src/logging.rs
+++ b/crates/kumod/src/logging.rs
@@ -378,7 +378,9 @@ impl Logger {
 
         for name in &self.meta {
             if let Ok(value) = msg.get_meta(name) {
-                meta.insert(name.to_string(), value);
+                if value.is_null() == false {
+                    meta.insert(name.to_string(), value);
+                }
             }
         }
 

--- a/crates/kumod/src/logging.rs
+++ b/crates/kumod/src/logging.rs
@@ -378,7 +378,7 @@ impl Logger {
 
         for name in &self.meta {
             if let Ok(value) = msg.get_meta(name) {
-                if value.is_null() == false {
+                if !value.is_null() {
                     meta.insert(name.to_string(), value);
                 }
             }


### PR DESCRIPTION
To keep it the same as headers, only add meta to logs if they are not null.