### PR TITLE
Documentation: define_egress_source and define_egress_pool are removed.

### DIFF
--- a/docs/reference/kumo/make_egress_source.md
+++ b/docs/reference/kumo/make_egress_source.md
@@ -15,9 +15,7 @@ A source must have at a minimum a *name*, which will be used in logging/reportin
 
 Required string.
 
-The name of the source. If you call `kumo.make_egress_source` multiple
-times with the same name, the most recently defined version of that name will replace
-any previously defined source with that name.
+The name of the source.
 
 ```lua
 kumo.on('get_egress_source', function(source_name)

--- a/docs/reference/kumo/make_egress_source.md
+++ b/docs/reference/kumo/make_egress_source.md
@@ -15,7 +15,7 @@ A source must have at a minimum a *name*, which will be used in logging/reportin
 
 Required string.
 
-The name of the source. If you call `kumo.define_egress_source` multiple
+The name of the source. If you call `kumo.make_egress_source` multiple
 times with the same name, the most recently defined version of that name will replace
 any previously defined source with that name.
 

--- a/docs/reference/queues.md
+++ b/docs/reference/queues.md
@@ -63,26 +63,26 @@ traffic to the destination domain.
 
 ```lua
 kumo.on('init', function()
-  kumo.define_egress_source {
+  kumo.make_egress_source {
     name = 'ip-1',
     source_address = '10.0.0.1',
   }
-  kumo.define_egress_source {
+  kumo.make_egress_source {
     name = 'ip-2',
     source_address = '10.0.0.2',
   }
-  kumo.define_egress_source {
+  kumo.make_egress_source {
     name = 'ip-3',
     source_address = '10.0.0.3',
   }
 
-  kumo.define_egress_pool {
+  kumo.make_egress_pool {
     name = 'pool1',
     entries = {
       { name = 'ip-1' },
     },
   }
-  kumo.define_egress_pool {
+  kumo.make_egress_pool {
     name = 'pool2',
     entries = {
       { name = 'ip-2', weight = 2 },

--- a/docs/reference/queues.md
+++ b/docs/reference/queues.md
@@ -62,7 +62,7 @@ a local IP address or configured to use an alternative destination port
 traffic to the destination domain.
 
 ```lua
-kumo.on('init', function()
+kumo.on('get_egress_source', function()
   kumo.make_egress_source {
     name = 'ip-1',
     source_address = '10.0.0.1',

--- a/docs/userguide/configuration/sendingips.md
+++ b/docs/userguide/configuration/sendingips.md
@@ -78,7 +78,7 @@ SMTP, it could also define a specific outbound port for sending through
 port-based NAT, or a specific configuration for sending over HTTP.
 
 An Egress Source is defined using the **`kumo.make_egress_source`** function,
-called during the init event. For more information, see the
+called during the **`kumo.get_egress_source`** event. For more information, see the
 [make_egress_source](../../reference/kumo/make_egress_source.md) chapter of the
 Reference Manual.
 

--- a/docs/userguide/operation/proxy.md
+++ b/docs/userguide/operation/proxy.md
@@ -24,7 +24,7 @@ Configuring an egress_source to use a SOCKS5 proxy server is done as part of the
 function call:
 
 ```lua
-kumo.on('init', function()
+kumo.on('get_egress_source', function()
   -- Make a source that will emit from 10.0.0.1, via a proxy server
   kumo.make_egress_source {
     name = 'ip-1',
@@ -63,7 +63,7 @@ Configuring an egress_source to use an HAProxy server is done as part of the `ma
 function call:
 
 ```lua
-kumo.on('init', function()
+kumo.on('get_egress_source', function()
   -- Make a source that will emit from 10.0.0.1, via a proxy server
   kumo.make_egress_source {
     name = 'ip-1',

--- a/docs/userguide/operation/proxy.md
+++ b/docs/userguide/operation/proxy.md
@@ -20,13 +20,13 @@ While KumoMTA will work with any compliant SOCKS5 proxy server, we have built Ku
 
 ### Configuring an egress_source for SOCKS5 Proxy Use
 
-Configuring an egress_source to use a SOCKS5 proxy server is done as part of the `define_egress_source`
+Configuring an egress_source to use a SOCKS5 proxy server is done as part of the `make_egress_source`
 function call:
 
 ```lua
 kumo.on('init', function()
   -- Make a source that will emit from 10.0.0.1, via a proxy server
-  kumo.define_egress_source {
+  kumo.make_egress_source {
     name = 'ip-1',
 
     -- The SOCKS5 proxy server address and port
@@ -59,13 +59,13 @@ messages via IP addresses on the HAProxy host.
 
 ### Configuring an egress_source for HAProxy Use
 
-Configuring an egress_source to use an HAProxy server is done as part of the `define_egress_source`
+Configuring an egress_source to use an HAProxy server is done as part of the `make_egress_source`
 function call:
 
 ```lua
 kumo.on('init', function()
   -- Make a source that will emit from 10.0.0.1, via a proxy server
-  kumo.define_egress_source {
+  kumo.make_egress_source {
     name = 'ip-1',
 
     -- The HAProxy server address and port


### PR DESCRIPTION
This PR replaces `define_egress_source` and `define_egress_pool` (deprecated in [Release 2023.06.22-51b72a83](https://docs.kumomta.com/changelog/2023.06.22-51b72a83/?h=define_egress_source#breaking-changes) ) with `make_egress_source` and `make_egress_pool` in the docs.
