### PR TITLE
add default to dkim over_sign

### DIFF
--- a/assets/policy-extras/dkim_sign.lua
+++ b/assets/policy-extras/dkim_sign.lua
@@ -231,6 +231,7 @@ local function do_dkim_sign(msg, data)
             or base.header_canonicalization,
           body_canonicalization = sig_config.body_canonicalization
             or base.body_canonicalization,
+          over_sign = sig_config.over_sign or base.over_sign,
         }
 
         if base.vault_mount then

--- a/crates/message/src/dkim.rs
+++ b/crates/message/src/dkim.rs
@@ -54,6 +54,7 @@ pub struct SignerConfig {
     body_canonicalization: Canon,
 
     key: KeySource,
+    #[serde(default)]
     over_sign: bool,
 
     #[serde(default = "SignerConfig::default_ttl")]


### PR DESCRIPTION
add default to dkim over_sign so it doesn't break deserialization if over_sign is not set. 