### PR TITLE
Remove ready_count metrics on site reap

### DIFF
--- a/crates/kumod/src/logging.rs
+++ b/crates/kumod/src/logging.rs
@@ -62,7 +62,7 @@ impl ClassifierParams {
 
         CLASSIFY
             .set(classifier)
-            .map_err(|_| anyhow::anyhow!("classifieer already initialized"))?;
+            .map_err(|_| anyhow::anyhow!("classifier already initialized"))?;
 
         Ok(())
     }

--- a/crates/kumod/src/metrics_helper.rs
+++ b/crates/kumod/src/metrics_helper.rs
@@ -103,4 +103,5 @@ pub fn remove_metrics_for_service(service: &str) {
     TOTAL_MSGS_DELIVERED.remove_label_values(&[service]).ok();
     TOTAL_MSGS_TRANSFAIL.remove_label_values(&[service]).ok();
     TOTAL_MSGS_FAIL.remove_label_values(&[service]).ok();
+    READY_COUNT_GAUGE.remove_label_values(&[service]).ok();
 }


### PR DESCRIPTION
Add READY_COUNT_GAUGE to the list of metrics to remove on site reap