### PR TITLE
Switch to debian bookwork for runtime docker image 

### DIFF
--- a/docker/kumod/Dockerfile
+++ b/docker/kumod/Dockerfile
@@ -29,7 +29,7 @@ RUN cargo build --release -p kumod && \
 # is problematic when built with musl.
 # <https://github.com/rust-rocksdb/rust-rocksdb/issues/174>.
 # It does compile, but it just SEGV'd on startup for me.
-FROM ubuntu:latest as runtime
+FROM debian:bookworm-slim as runtime
 # Create a user and group to run as.
 # Note that we don't use the docker USER here because we need to
 # start as root and then drop to this user. That is handled by

--- a/docker/kumod/Dockerfile
+++ b/docker/kumod/Dockerfile
@@ -35,7 +35,7 @@ FROM ubuntu:latest as runtime
 # start as root and then drop to this user. That is handled by
 # the docker-runner.sh script.
 RUN groupadd --system --gid 1000 kumod && useradd --system --gid kumod --uid 1000 kumod
-RUN apt update && apt install -y libsqlite3-dev
+RUN apt update && apt install -y libsqlite3-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /opt/kumomta/sbin
 COPY --from=builder /app/target/release/kcli .
 COPY --from=builder /app/target/release/kumod .


### PR DESCRIPTION
This ensures the same os base as cargo chef, which in theory should help minimize breaking changes. It also fixes a conflict with uid/gid 1000 that was present in the ubuntu base due to the ubuntu user/group being uid/gid 1000.