### PR TITLE
use nanoseconds in redis lease durations

### DIFF
--- a/crates/throttle/src/lib.rs
+++ b/crates/throttle/src/lib.rs
@@ -201,11 +201,11 @@ async fn redis_throttle(
         throttled: result[0] != 0,
         limit: result[1] as u64,
         remaining: result[2] as u64,
-        reset_after: Duration::from_secs(result[3].max(0) as u64),
-        retry_after: match result[4] {
+        retry_after: match result[3] {
             n if n < 0 => None,
             n => Some(Duration::from_secs(n as u64)),
         },
+        reset_after: Duration::from_secs(result[4].max(0) as u64),
     })
 }
 

--- a/crates/throttle/src/limit.rs
+++ b/crates/throttle/src/limit.rs
@@ -73,10 +73,10 @@ impl LimitSpec {
     ) -> Result<LimitLease, Error> {
         let now_ts = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0);
 
-        let expires_ts = now_ts + self.duration.as_secs();
+        let expires_ts = now_ts + self.duration.as_secs_f64();
         let uuid = Uuid::new_v4();
         let uuid_str = uuid.to_string();
 
@@ -187,10 +187,10 @@ impl LimitLease {
     async fn extend_redis(&self, conn: RedisConnection, duration: Duration) -> Result<(), Error> {
         let now_ts = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0);
 
-        let expires = now_ts + duration.as_secs();
+        let expires = now_ts + duration.as_secs_f64();
 
         let mut cmd = mod_redis::cmd("ZADD");
         cmd.arg(&self.name)


### PR DESCRIPTION
Use as_sec_f64 for more details, because the extend method fails if the expires value is the same. Also set redis-cell response to corresponding attributes.