### PR TITLE
Patch bug in log_hooks.lua

### DIFF
--- a/assets/policy-extras/log_hooks.lua
+++ b/assets/policy-extras/log_hooks.lua
@@ -214,11 +214,12 @@ function mod:new_json(options)
       -- it reached it expiration.
       kumo.reject(500, disposition)
     end
-    return connection
-  end
 
-  function connection:close()
-    client:close()
+    function connection:close()
+      client:close()
+    end
+    
+    return connection
   end
 
   return self:new(options)

--- a/assets/policy-extras/log_hooks.lua
+++ b/assets/policy-extras/log_hooks.lua
@@ -218,7 +218,7 @@ function mod:new_json(options)
     function connection:close()
       client:close()
     end
-    
+
     return connection
   end
 


### PR DESCRIPTION
I believe connection:close was inserted in the wrong place and should be inside the constructor function with the connection object.

Using version 2024.07.24-84bc2f05 causes crash when calling log_hooks:new_json