### PR TITLE
shaping: add provider concept to shaping helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,6 +2844,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "spool",
+ "tempfile",
  "throttle",
  "tokio",
  "toml",

--- a/assets/policy-extras/shaping.toml
+++ b/assets/policy-extras/shaping.toml
@@ -138,3 +138,4 @@ connection_limit = 3
 # your overrides there.
 ["example.com".sources."my source name"]
 connection_limit = 5
+

--- a/crates/kumo-api-types/Cargo.toml
+++ b/crates/kumo-api-types/Cargo.toml
@@ -41,4 +41,5 @@ uuid = {workspace=true, features=["serde"]}
 
 [dev-dependencies]
 k9 = "0.12"
+tempfile.workspace = true
 tokio = {workspace=true, features=["full"]}

--- a/crates/kumo-api-types/src/egress_path.rs
+++ b/crates/kumo-api-types/src/egress_path.rs
@@ -3,6 +3,7 @@ use data_loader::KeySource;
 #[cfg(feature = "lua")]
 use mlua::prelude::*;
 use openssl::ssl::SslOptions;
+use ordermap::OrderMap;
 use rfc5321::SmtpClientTimeouts;
 use rustls::SupportedCipherSuite;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -131,6 +132,9 @@ pub struct EgressPathConfig {
     pub connection_limit: usize,
 
     #[serde(default)]
+    pub additional_connection_limits: OrderMap<String, usize>,
+
+    #[serde(default)]
     pub enable_tls: Tls,
 
     #[serde(default = "EgressPathConfig::default_enable_mta_sts")]
@@ -175,6 +179,9 @@ pub struct EgressPathConfig {
 
     #[serde(default)]
     pub max_message_rate: Option<ThrottleSpec>,
+
+    #[serde(default)]
+    pub additional_message_rate_throttles: OrderMap<String, ThrottleSpec>,
 
     #[serde(default)]
     pub max_connection_rate: Option<ThrottleSpec>,
@@ -233,6 +240,8 @@ impl Default for EgressPathConfig {
             openssl_cipher_list: None,
             openssl_cipher_suites: None,
             openssl_options: None,
+            additional_message_rate_throttles: OrderMap::default(),
+            additional_connection_limits: OrderMap::default(),
         }
     }
 }

--- a/crates/kumo-api-types/src/shaping.rs
+++ b/crates/kumo-api-types/src/shaping.rs
@@ -245,12 +245,13 @@ impl Rule {
 struct ShapingInner {
     by_site: OrderMap<String, PartialEntry>,
     by_domain: OrderMap<String, PartialEntry>,
+    by_provider: OrderMap<String, ProviderEntry>,
     warnings: Vec<String>,
 }
 
 #[cfg(feature = "lua")]
 impl ShapingInner {
-    pub fn get_egress_path_config(
+    pub async fn get_egress_path_config(
         &self,
         domain: &str,
         egress_source: &str,
@@ -261,6 +262,27 @@ impl ShapingInner {
         // Apply basic/default configuration
         if let Some(default) = self.by_domain.get("default") {
             params.merge_from(default.clone());
+        }
+
+        // Provider rules come next
+        for prov in self.by_provider.values() {
+            if prov.domain_matches(domain).await {
+                toml_table_merge_from(&mut params.params, &prov.params);
+                prov.apply_provider_params_to(egress_source, &mut params.params);
+            }
+        }
+
+        // Then Provider source rules
+        for prov in self.by_provider.values() {
+            if prov.sources.is_empty() {
+                continue;
+            }
+            if prov.domain_matches(domain).await {
+                if let Some(source) = prov.sources.get(egress_source) {
+                    toml_table_merge_from(&mut params.params, &source);
+                    prov.apply_provider_params_to(egress_source, &mut params.params);
+                }
+            }
         }
 
         // Then site config
@@ -290,7 +312,7 @@ impl ShapingInner {
         params
     }
 
-    pub fn match_rules(&self, record: &JsonLogRecord) -> anyhow::Result<Vec<Rule>> {
+    pub async fn match_rules(&self, record: &JsonLogRecord) -> anyhow::Result<Vec<Rule>> {
         use rfc5321::ForwardPath;
         // Extract the domain from the recipient.
         let recipient = ForwardPath::try_from(record.recipient.as_str())
@@ -386,7 +408,7 @@ pub struct Shaping {
 
 #[cfg(feature = "lua")]
 impl Shaping {
-    async fn load_from_file(path: &str) -> anyhow::Result<OrderMap<String, PartialEntry>> {
+    async fn load_from_file(path: &str) -> anyhow::Result<ShapingFile> {
         let data: String = if path.starts_with("http://") || path.starts_with("https://") {
             // To facilitate startup ordering races, and listing multiple subscription
             // host replicas and allowing one or more of them to be temporarily down,
@@ -406,7 +428,7 @@ impl Shaping {
                 Ok(s) => s,
                 Err(err) => {
                     tracing::error!("{err:#}. Ignoring this shaping source for now");
-                    return Ok(OrderMap::new());
+                    return Ok(ShapingFile::default());
                 }
             }
         } else {
@@ -416,8 +438,21 @@ impl Shaping {
 
         if path.ends_with(".toml") {
             toml::from_str(&data).with_context(|| format!("parsing toml from file {path}"))
-        } else {
+        } else if path.ends_with(".json") {
             serde_json::from_str(&data).with_context(|| format!("parsing json from file {path}"))
+        } else {
+            // Try parsing both ways and see which wins
+            let mut errors = vec![];
+            match toml::from_str(&data) {
+                Ok(s) => return Ok(s),
+                Err(err) => errors.push(format!("as toml: {err:#}")),
+            }
+            match serde_json::from_str(&data) {
+                Ok(s) => return Ok(s),
+                Err(err) => errors.push(format!("as json: {err:#}")),
+            }
+
+            anyhow::bail!("parsing {path}: {}", errors.join(", "));
         }
     }
 
@@ -432,6 +467,7 @@ impl Shaping {
 
         let mut by_site: OrderMap<String, PartialEntry> = OrderMap::new();
         let mut by_domain: OrderMap<String, PartialEntry> = OrderMap::new();
+        let mut by_provider: OrderMap<String, ProviderEntry> = OrderMap::new();
         let mut warnings = vec![];
 
         // Pre-resolve domains. We don't interleave the resolution with
@@ -441,14 +477,8 @@ impl Shaping {
         let mut mx = std::collections::HashMap::new();
         let mut lookups = FuturesUnordered::new();
         for item in &loaded {
-            for (domain, partial) in item {
-                let mx_rollup = if domain == "default" {
-                    false
-                } else {
-                    partial.mx_rollup
-                };
-
-                if mx_rollup {
+            for (domain, partial) in &item.domains {
+                if partial.mx_rollup {
                     let domain = domain.to_string();
                     let limiter = limiter.clone();
                     lookups.push(tokio::spawn(async move {
@@ -469,29 +499,36 @@ impl Shaping {
             mx.insert(domain, result);
         }
 
-        for item in loaded {
-            for (domain, mut partial) in item {
+        for mut item in loaded {
+            if let Some(mut partial) = item.default.take() {
+                let domain = "default";
+                partial.domain_name.replace(domain.to_string());
+                match by_domain.get_mut(domain) {
+                    Some(existing) => {
+                        existing.merge_from(partial);
+                    }
+                    None => {
+                        by_domain.insert(domain.to_string(), partial);
+                    }
+                }
+            }
+
+            for (domain, mut partial) in item.domains {
                 partial.domain_name.replace(domain.clone());
 
-                let mx_rollup = if domain == "default" {
-                    false
-                } else {
-                    if let Ok(name) = fully_qualify(&domain) {
-                        if name.num_labels() == 1 {
-                            warnings.push(format!(
-                                "Entry for domain '{domain}' consists of a \
+                if let Ok(name) = fully_qualify(&domain) {
+                    if name.num_labels() == 1 {
+                        warnings.push(format!(
+                            "Entry for domain '{domain}' consists of a \
                                  single DNS label. Domain names in TOML sections \
                                  need to be quoted like '[\"{domain}.com\"]` otherwise \
                                  the '.' will create a nested table rather than being \
                                  added to the domain name."
-                            ));
-                        }
+                        ));
                     }
+                }
 
-                    partial.mx_rollup
-                };
-
-                if mx_rollup {
+                if partial.mx_rollup {
                     let mx = match mx.get(&domain) {
                         Some(Ok(mx)) => mx,
                         Some(Err(err)) => {
@@ -536,6 +573,18 @@ impl Shaping {
                     }
                 }
             }
+
+            for (provider, mut prov) in item.provider {
+                prov.provider_name = provider.to_string();
+                match by_provider.get_mut(&provider) {
+                    Some(existing) => {
+                        existing.merge_from(prov);
+                    }
+                    None => {
+                        by_provider.insert(provider.to_string(), prov);
+                    }
+                }
+            }
         }
 
         for (site, partial) in &by_site {
@@ -552,16 +601,22 @@ impl Shaping {
                 .with_context(|| format!("domain: {domain}"))?;
         }
 
+        for (provider, prov) in &by_provider {
+            prov.finish_params()
+                .with_context(|| format!("provider: {provider}"))?;
+        }
+
         Ok(Self {
             inner: Arc::new(ShapingInner {
                 by_site,
                 by_domain,
+                by_provider,
                 warnings,
             }),
         })
     }
 
-    fn get_egress_path_config(
+    async fn get_egress_path_config(
         &self,
         domain: &str,
         egress_source: &str,
@@ -569,14 +624,15 @@ impl Shaping {
     ) -> PartialEntry {
         self.inner
             .get_egress_path_config(domain, egress_source, site_name)
+            .await
     }
 
     pub fn get_warnings(&self) -> &[String] {
         &self.inner.warnings
     }
 
-    pub fn match_rules(&self, record: &JsonLogRecord) -> anyhow::Result<Vec<Rule>> {
-        self.inner.match_rules(record)
+    pub async fn match_rules(&self, record: &JsonLogRecord) -> anyhow::Result<Vec<Rule>> {
+        self.inner.match_rules(record).await
     }
 
     pub fn get_referenced_sources(&self) -> BTreeMap<String, Vec<String>> {
@@ -607,10 +663,12 @@ impl Shaping {
 impl LuaUserData for Shaping {
     fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
         mod_memoize::Memoized::impl_memoize(methods);
-        methods.add_method(
+        methods.add_async_method(
             "get_egress_path_config",
-            move |lua, this, (domain, egress_source, site_name): (String, String, String)| {
-                let params = this.get_egress_path_config(&domain, &egress_source, &site_name);
+            |lua, this, (domain, egress_source, site_name): (String, String, String)| async move {
+                let params = this
+                    .get_egress_path_config(&domain, &egress_source, &site_name)
+                    .await;
                 lua.to_value_with(&params.params, serialize_options())
             },
         );
@@ -623,9 +681,9 @@ impl LuaUserData for Shaping {
             Ok(this.get_referenced_sources())
         });
 
-        methods.add_method("match_rules", move |lua, this, record: mlua::Value| {
+        methods.add_async_method("match_rules", |lua, this, record: mlua::Value| async move {
             let record: JsonLogRecord = lua.from_value(record)?;
-            let rules = this.match_rules(&record).map_err(any_err)?;
+            let rules = this.match_rules(&record).await.map_err(any_err)?;
             let mut result = vec![];
             for rule in rules {
                 result.push(lua.to_value(&rule)?);
@@ -640,6 +698,16 @@ pub struct MergedEntry {
     pub params: EgressPathConfig,
     pub sources: OrderMap<String, EgressPathConfig>,
     pub automation: Vec<Rule>,
+}
+
+#[cfg(feature = "lua")]
+#[derive(Deserialize, Debug, Clone, Default)]
+struct ShapingFile {
+    pub default: Option<PartialEntry>,
+    #[serde(flatten, default)]
+    pub domains: OrderMap<String, PartialEntry>,
+    #[serde(default)]
+    pub provider: OrderMap<String, ProviderEntry>,
 }
 
 #[cfg(feature = "lua")]
@@ -665,9 +733,241 @@ struct PartialEntry {
 }
 
 #[cfg(feature = "lua")]
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct ProviderEntry {
+    #[serde(skip, default)]
+    pub provider_name: String,
+
+    #[serde(default)]
+    pub provider_connection_limit: Option<usize>,
+
+    #[serde(default)]
+    pub provider_max_message_rate: Option<ThrottleSpec>,
+
+    #[serde(default, rename = "match")]
+    pub matches: Vec<ProviderMatch>,
+
+    #[serde(default)]
+    pub replace_base: bool,
+
+    #[serde(flatten)]
+    pub params: toml::Table,
+
+    #[serde(default)]
+    pub automation: Vec<Rule>,
+
+    #[serde(default)]
+    pub sources: OrderMap<String, toml::Table>,
+}
+
+fn suffix_matches(candidate: &str, suffix: &str) -> bool {
+    // Remove trailing dot from candidate, as our resolver tends
+    // to leave the canonical dot on the input host name
+    let candidate = candidate.strip_suffix(".").unwrap_or(candidate);
+    if candidate.len() < suffix.len() {
+        return false;
+    }
+    let candidate = &candidate[candidate.len() - suffix.len()..];
+    candidate.eq_ignore_ascii_case(suffix)
+}
+
+#[cfg(test)]
+#[test]
+fn test_suffix_matches() {
+    assert!(suffix_matches("a", "a"));
+    assert!(suffix_matches("foo.Com", ".com"));
+    assert!(!suffix_matches("foo.Cam", ".com"));
+    assert!(suffix_matches("foo.com", "foo.com"));
+    assert!(!suffix_matches("foo.com", ".foo.com"));
+    assert!(!suffix_matches("foo.com", "longer.com"));
+}
+
+#[cfg(feature = "lua")]
+impl ProviderEntry {
+    async fn domain_matches(&self, domain: &str) -> bool {
+        // We'd like to avoid doing DNS if we can do a simple suffix match,
+        // so we bias to looking at those first
+        let mut has_mx_rules = false;
+
+        for rule in &self.matches {
+            match rule {
+                ProviderMatch::DomainSuffix(suffix) => {
+                    if suffix_matches(domain, suffix) {
+                        return true;
+                    }
+                }
+                ProviderMatch::MXSuffix(_) => {
+                    has_mx_rules = true;
+                }
+            }
+        }
+
+        if !has_mx_rules {
+            return false;
+        }
+
+        // Now we can consider DNS
+        match MailExchanger::resolve(&domain).await {
+            Err(err) => {
+                tracing::error!(
+                    "Error resolving MX for {domain}: {err:#}. \
+                    Provider {} match rules will be ignored",
+                    self.provider_name
+                );
+                false
+            }
+            Ok(mx) => {
+                for rule in &self.matches {
+                    match rule {
+                        ProviderMatch::MXSuffix(suffix) => {
+                            // For a given MX suffix rule, all hosts must match
+                            // it for it to be valid. This is so that we don't
+                            // falsely lump a vanity domain that blends providers
+                            // together.
+                            let mut matched = true;
+                            for host in &mx.hosts {
+                                if !suffix_matches(host, suffix) {
+                                    matched = false;
+                                    break;
+                                }
+                            }
+
+                            if matched {
+                                return true;
+                            }
+                        }
+                        ProviderMatch::DomainSuffix(_) => {}
+                    }
+                }
+
+                false
+            }
+        }
+    }
+
+    fn merge_from(&mut self, mut other: Self) {
+        if other.replace_base {
+            self.provider_connection_limit = other.provider_connection_limit;
+            self.matches = other.matches;
+            self.params = other.params;
+            self.sources = other.sources;
+            self.automation = other.automation;
+        } else {
+            if other.provider_connection_limit.is_some() {
+                self.provider_connection_limit = other.provider_connection_limit;
+            }
+
+            toml_table_merge_from(&mut self.params, &other.params);
+
+            for (source, tbl) in other.sources {
+                match self.sources.get_mut(&source) {
+                    Some(existing) => {
+                        toml_table_merge_from(existing, &tbl);
+                    }
+                    None => {
+                        self.sources.insert(source, tbl);
+                    }
+                }
+            }
+
+            self.matches.append(&mut other.matches);
+            self.automation.append(&mut other.automation);
+        }
+    }
+
+    fn apply_provider_params_to(&self, source: &str, target: &mut toml::Table) {
+        let mut implied = toml::Table::new();
+        if let Some(limit) = &self.provider_connection_limit {
+            let mut limits = toml::Table::new();
+            limits.insert(
+                format!("shaping-provider-{}-{source}-limit", self.provider_name),
+                toml::Value::Integer((*limit) as i64),
+            );
+            implied.insert(
+                "additional_connection_limits".to_string(),
+                toml::Value::Table(limits),
+            );
+        }
+        if let Some(rate) = &self.provider_max_message_rate {
+            match rate.as_string() {
+                Ok(rate) => {
+                    let mut limits = toml::Table::new();
+                    limits.insert(
+                        format!("shaping-provider-{}-{source}-rate", self.provider_name),
+                        rate.into(),
+                    );
+                    implied.insert(
+                        "additional_message_rate_throttles".to_string(),
+                        toml::Value::Table(limits),
+                    );
+                }
+                Err(err) => {
+                    tracing::error!("Error representing provider_max_message_rate: {err}");
+                }
+            }
+        }
+
+        toml_table_merge_from(target, &implied);
+    }
+
+    fn finish_params(&self) -> anyhow::Result<MergedEntry> {
+        let provider_name = &self.provider_name;
+
+        let params = EgressPathConfig::deserialize(self.params.clone()).with_context(|| {
+            format!(
+                "interpreting provider '{provider_name}' params {:#?} as EgressPathConfig",
+                self.params
+            )
+        })?;
+        let mut sources = OrderMap::new();
+
+        for (source, params) in &self.sources {
+            sources.insert(
+                source.clone(),
+                EgressPathConfig::deserialize(params.clone()).with_context(|| {
+                    format!("interpreting provider '{provider_name}' source '{source}' {params:#} as EgressPathConfig")
+                })?,
+            );
+        }
+
+        Ok(MergedEntry {
+            params,
+            sources,
+            automation: self.automation.clone(),
+        })
+    }
+}
+
+#[cfg(feature = "lua")]
+#[derive(Deserialize, Debug, Clone)]
+pub enum ProviderMatch {
+    MXSuffix(String),
+    DomainSuffix(String),
+}
+
+#[cfg(feature = "lua")]
 fn toml_table_merge_from(tbl: &mut toml::Table, source: &toml::Table) {
+    // Limit merging to just the throttle related fields, as their purpose
+    // is for creating broader scoped limits that cut across normal boundaries
+    fn is_mergeable(name: &str) -> bool {
+        match name {
+            "additional_connection_limits" | "additional_message_rate_throttles" => true,
+            _ => false,
+        }
+    }
+
     for (k, v) in source {
-        tbl.insert(k.clone(), v.clone());
+        match (tbl.get_mut(k), v.as_table()) {
+            // Merge Table values together, rather than simply replacing them.
+            (Some(toml::Value::Table(existing)), Some(v)) if is_mergeable(k) => {
+                for (inner_k, inner_v) in v {
+                    existing.insert(inner_k.clone(), inner_v.clone());
+                }
+            }
+            _ => {
+                tbl.insert(k.clone(), v.clone());
+            }
+        }
     }
 }
 
@@ -791,6 +1091,112 @@ pub fn register(lua: &mlua::Lua) -> anyhow::Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    async fn make_shaping_configs(inputs: &[&str]) -> Shaping {
+        let mut files = vec![];
+        let mut file_names = vec![];
+
+        for (i, content) in inputs.iter().enumerate() {
+            let mut shaping_file = NamedTempFile::with_prefix(format!("file{i}")).unwrap();
+            shaping_file.write_all(content.as_bytes()).unwrap();
+            file_names.push(shaping_file.path().to_str().unwrap().to_string());
+            files.push(shaping_file);
+        }
+
+        Shaping::merge_files(&file_names).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_merge_additional() {
+        let shaping = make_shaping_configs(&[
+            r#"
+["example.com"]
+mx_rollup = false
+additional_connection_limits = {"first"=10}
+        "#,
+            r#"
+["example.com"]
+mx_rollup = false
+additional_connection_limits = {"second"=32}
+additional_message_rate_throttles = {"second"="100/hr"}
+        "#,
+        ])
+        .await;
+
+        let resolved = shaping
+            .get_egress_path_config("example.com", "invalid.source", "invalid.site")
+            .await
+            .finish()
+            .unwrap();
+
+        k9::snapshot!(
+            resolved.params.additional_connection_limits,
+            r#"
+{
+    "first": 10,
+    "second": 32,
+}
+"#
+        );
+        k9::snapshot!(
+            resolved.params.additional_message_rate_throttles,
+            r#"
+{
+    "second": ThrottleSpec {
+        limit: 100,
+        period: 3600,
+        max_burst: None,
+    },
+}
+"#
+        );
+    }
+
+    #[tokio::test]
+    async fn test_provider() {
+        let shaping = make_shaping_configs(&[r#"
+[provider."Office 365"]
+match=[{MXSuffix=".olc.protection.outlook.com"},{DomainSuffix=".outlook.com"}]
+enable_tls = "Required"
+provider_connection_limit = 10
+provider_max_message_rate = "120/s"
+        "#])
+        .await;
+
+        let resolved = shaping
+            .get_egress_path_config("outlook.com", "invalid.source", "invalid.site")
+            .await
+            .finish()
+            .unwrap();
+
+        k9::assert_equal!(
+            resolved.params.enable_tls,
+            crate::egress_path::Tls::Required
+        );
+
+        k9::snapshot!(
+            resolved.params.additional_connection_limits,
+            r#"
+{
+    "shaping-provider-Office 365-invalid.source-limit": 10,
+}
+"#
+        );
+        k9::snapshot!(
+            resolved.params.additional_message_rate_throttles,
+            r#"
+{
+    "shaping-provider-Office 365-invalid.source-rate": ThrottleSpec {
+        limit: 120,
+        period: 1,
+        max_burst: None,
+    },
+}
+"#
+        );
+    }
 
     #[tokio::test]
     async fn test_defaults() {
@@ -800,6 +1206,7 @@ mod test {
 
         let default = shaping
             .get_egress_path_config("invalid.domain", "invalid.source", "invalid.site")
+            .await
             .finish()
             .unwrap();
         k9::snapshot!(
@@ -808,6 +1215,7 @@ mod test {
 MergedEntry {
     params: EgressPathConfig {
         connection_limit: 10,
+        additional_connection_limits: {},
         enable_tls: Opportunistic,
         enable_mta_sts: true,
         enable_dane: false,
@@ -842,6 +1250,7 @@ MergedEntry {
                 max_burst: None,
             },
         ),
+        additional_message_rate_throttles: {},
         max_connection_rate: Some(
             ThrottleSpec {
                 limit: 100,
@@ -963,6 +1372,7 @@ MergedEntry {
 
         let example_com = shaping
             .get_egress_path_config("example.com", "invalid.source", "invalid.site")
+            .await
             .finish()
             .unwrap();
         k9::snapshot!(
@@ -971,6 +1381,7 @@ MergedEntry {
 MergedEntry {
     params: EgressPathConfig {
         connection_limit: 3,
+        additional_connection_limits: {},
         enable_tls: Opportunistic,
         enable_mta_sts: true,
         enable_dane: false,
@@ -1005,6 +1416,7 @@ MergedEntry {
                 max_burst: None,
             },
         ),
+        additional_message_rate_throttles: {},
         max_connection_rate: Some(
             ThrottleSpec {
                 limit: 100,
@@ -1054,6 +1466,7 @@ MergedEntry {
     sources: {
         "my source name": EgressPathConfig {
             connection_limit: 5,
+            additional_connection_limits: {},
             enable_tls: Opportunistic,
             enable_mta_sts: true,
             enable_dane: false,
@@ -1082,6 +1495,7 @@ MergedEntry {
             smtp_auth_plain_password: None,
             allow_smtp_auth_plain_without_tls: false,
             max_message_rate: None,
+            additional_message_rate_throttles: {},
             max_connection_rate: None,
             max_deliveries_per_connection: 1024,
             prohibited_hosts: CidrSet(
@@ -1203,6 +1617,7 @@ MergedEntry {
                 "invalid.source",
                 "(mta5|mta6|mta7).am0.yahoodns.net",
             )
+            .await
             .finish()
             .unwrap();
         k9::snapshot!(
@@ -1211,6 +1626,7 @@ MergedEntry {
 MergedEntry {
     params: EgressPathConfig {
         connection_limit: 10,
+        additional_connection_limits: {},
         enable_tls: Opportunistic,
         enable_mta_sts: true,
         enable_dane: false,
@@ -1245,6 +1661,7 @@ MergedEntry {
                 max_burst: None,
             },
         ),
+        additional_message_rate_throttles: {},
         max_connection_rate: Some(
             ThrottleSpec {
                 limit: 100,

--- a/crates/kumod/src/ready_queue.rs
+++ b/crates/kumod/src/ready_queue.rs
@@ -32,6 +32,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use throttle::limit::{LimitLease, LimitSpec};
+use throttle::ThrottleSpec;
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tracing::instrument; // TODO move to here
@@ -657,78 +658,101 @@ impl ReadyQueue {
         );
 
         if current_connection_count < ideal {
-            let limit = LimitSpec {
-                limit: path_config.connection_limit,
-                duration: path_config.client_timeouts.total_message_send_duration(),
-            };
+            let lease_duration = path_config.client_timeouts.total_message_send_duration();
+            let limit_name = format!("kumomta.connection_limit.{}", self.name);
+            let mut limits = vec![(
+                &limit_name,
+                LimitSpec {
+                    limit: path_config.connection_limit,
+                    duration: lease_duration,
+                },
+            )];
 
-            for _ in current_connection_count..ideal {
-                match limit.acquire_lease(&self.name).await {
-                    Ok(lease) => {
-                        // Open a new connection
-                        let name = self.name.clone();
-                        let queue_name_for_config_change_purposes_only =
-                            self.queue_name_for_config_change_purposes_only.clone();
-                        let mx = self.mx.clone();
-                        let ready = Arc::clone(&self.ready);
-                        let notify_dispatcher = self.notify_dispatcher.clone();
-                        let path_config = self.path_config.clone();
-                        let queue_config = self.queue_config.clone();
-                        let metrics = self.metrics.clone();
-                        let egress_source = self.egress_source.clone();
-                        let egress_pool = self.egress_pool.clone();
-                        let consecutive_connection_failures =
-                            self.consecutive_connection_failures.clone();
+            for (label, limit) in &path_config.additional_connection_limits {
+                limits.push((
+                    label,
+                    LimitSpec {
+                        limit: *limit,
+                        duration: lease_duration,
+                    },
+                ));
+            }
+            // Check limits from smallest to largest so that we avoid
+            // taking up a slot from a larger one only to hit a smaller
+            // one and not do anything useful with the larger one
+            limits.sort_by_key(|(_, LimitSpec { limit, .. })| *limit);
 
-                        tracing::trace!("spawning client for {name}");
-                        if let Ok(handle) = READYQ_RUNTIME
-                            .spawn(format!("smtp client {name}"), move || {
-                                Ok(async move {
-                                    if let Err(err) = Dispatcher::run(
-                                        &name,
-                                        queue_name_for_config_change_purposes_only,
-                                        mx,
-                                        ready,
-                                        notify_dispatcher,
-                                        queue_config,
-                                        path_config,
-                                        metrics,
-                                        consecutive_connection_failures.clone(),
-                                        egress_source,
-                                        egress_pool,
-                                        lease,
-                                    )
-                                    .await
-                                    {
-                                        tracing::debug!(
-                                            "Error in Dispatcher::run for {name}: {err:#} \
-                         (consecutive_connection_failures={consecutive_connection_failures:?})"
-                                        );
-                                    }
-                                })
-                            })
-                            .await
-                        {
-                            self.connections.lock().push(handle);
+            'new_dispatcher: for _ in current_connection_count..ideal {
+                let mut leases = vec![];
+                for (label, limit) in &limits {
+                    match limit.acquire_lease(label).await {
+                        Ok(lease) => {
+                            leases.push(lease);
+                        }
+                        Err(err @ throttle::Error::TooManyLeases(_)) => {
+                            // Over budget; we'll try again later
+                            tracing::debug!(
+                                "maintain {}: could not acquire connection lease {label}: {err:#}",
+                                self.name
+                            );
+                            break 'new_dispatcher;
+                        }
+                        Err(err) => {
+                            // Some kind of error trying to acquire the lease, could be
+                            // a redis/connectivity error, let's surface it
+                            tracing::error!(
+                                "maintain {}: could not acquire connection lease {label}: {err:#}",
+                                self.name
+                            );
+                            break 'new_dispatcher;
                         }
                     }
-                    Err(err @ throttle::Error::TooManyLeases(_)) => {
-                        // Over budget; we'll try again later
-                        tracing::debug!(
-                            "maintain {}: could not acquire connection lease: {err:#}",
-                            self.name
-                        );
-                        break;
-                    }
-                    Err(err) => {
-                        // Some kind of error trying to acquire the lease, could be
-                        // a redis/connectivity error, let's surface it
-                        tracing::error!(
-                            "maintain {}: could not acquire connection lease: {err:#}",
-                            self.name
-                        );
-                        break;
-                    }
+                }
+
+                // Open a new connection
+                let name = self.name.clone();
+                let queue_name_for_config_change_purposes_only =
+                    self.queue_name_for_config_change_purposes_only.clone();
+                let mx = self.mx.clone();
+                let ready = Arc::clone(&self.ready);
+                let notify_dispatcher = self.notify_dispatcher.clone();
+                let path_config = self.path_config.clone();
+                let queue_config = self.queue_config.clone();
+                let metrics = self.metrics.clone();
+                let egress_source = self.egress_source.clone();
+                let egress_pool = self.egress_pool.clone();
+                let consecutive_connection_failures = self.consecutive_connection_failures.clone();
+
+                tracing::trace!("spawning client for {name}");
+                if let Ok(handle) = READYQ_RUNTIME
+                    .spawn(format!("smtp client {name}"), move || {
+                        Ok(async move {
+                            if let Err(err) = Dispatcher::run(
+                                &name,
+                                queue_name_for_config_change_purposes_only,
+                                mx,
+                                ready,
+                                notify_dispatcher,
+                                queue_config,
+                                path_config,
+                                metrics,
+                                consecutive_connection_failures.clone(),
+                                egress_source,
+                                egress_pool,
+                                leases,
+                            )
+                            .await
+                            {
+                                tracing::debug!(
+                                    "Error in Dispatcher::run for {name}: {err:#} \
+                         (consecutive_connection_failures={consecutive_connection_failures:?})"
+                                );
+                            }
+                        })
+                    })
+                    .await
+                {
+                    self.connections.lock().push(handle);
                 }
             }
         }
@@ -792,7 +816,7 @@ pub struct Dispatcher {
     pub msg: Option<Message>,
     pub delivery_protocol: String,
     pub suspended: Option<AdminSuspendReadyQEntryRef>,
-    lease: LimitLease,
+    leases: Vec<LimitLease>,
 }
 
 impl Drop for Dispatcher {
@@ -841,7 +865,7 @@ impl Dispatcher {
         consecutive_connection_failures: Arc<AtomicUsize>,
         egress_source: EgressSource,
         egress_pool: String,
-        lease: LimitLease,
+        leases: Vec<LimitLease>,
     ) -> anyhow::Result<()> {
         let activity = Activity::get(format!("ready_queue Dispatcher {name}"))?;
 
@@ -865,7 +889,7 @@ impl Dispatcher {
             egress_pool,
             delivered_this_connection: 0,
             delivery_protocol,
-            lease,
+            leases,
             suspended: None,
         };
 
@@ -898,7 +922,7 @@ impl Dispatcher {
             if dispatcher.msg.is_none() {
                 // We raced with another dispatcher and there is no
                 // more work to be done; no need to open a new connection.
-                dispatcher.lease.release().await;
+                dispatcher.release_leases().await;
                 return Ok(());
             }
         }
@@ -915,7 +939,7 @@ impl Dispatcher {
                 // No more messages within our idle time; we can close
                 // the connection
                 tracing::debug!("{} Idling out connection", dispatcher.name);
-                dispatcher.lease.release().await;
+                dispatcher.release_leases().await;
                 queue_dispatcher.close_connection(&mut dispatcher).await?;
                 return Ok(());
             }
@@ -923,7 +947,7 @@ impl Dispatcher {
             let result = tokio::select! {
                 _ = shutting_down.shutting_down() => {
                     tracing::debug!("{} shutting down", dispatcher.name);
-                    dispatcher.lease.release().await;
+                    dispatcher.release_leases().await;
                     queue_dispatcher.close_connection(&mut dispatcher).await?;
                     return Ok(());
                 }
@@ -986,7 +1010,7 @@ impl Dispatcher {
                     {
                         dispatcher.delay_ready_queue().await;
                     }
-                    dispatcher.lease.release().await;
+                    dispatcher.release_leases().await;
                     return Err(err);
                 }
                 tracing::debug!("{err:#}");
@@ -1002,6 +1026,38 @@ impl Dispatcher {
                 .deliver_message(&mut *queue_dispatcher)
                 .await
                 .context("deliver_message")?;
+        }
+    }
+
+    async fn check_throttle(
+        &mut self,
+        throttle: &ThrottleSpec,
+        throttle_key: &str,
+        throttle_label: &str,
+        path_config: &EgressPathConfig,
+    ) -> anyhow::Result<bool> {
+        loop {
+            let result = throttle
+                .throttle(throttle_key)
+                .await
+                .with_context(|| format!("apply {throttle_label} throttle"))?;
+
+            if let Some(delay) = result.retry_after {
+                if delay >= path_config.client_timeouts.idle_timeout {
+                    self.throttle_ready_queue(delay).await;
+                    return Ok(true);
+                }
+                tracing::trace!("{} throttled message rate, sleep for {delay:?}", self.name);
+                let mut shutdown = ShutdownSubcription::get();
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {},
+                    _ = shutdown.shutting_down() => {
+                        return Ok(true);
+                    }
+                };
+            } else {
+                return Ok(false);
+            }
         }
     }
 
@@ -1025,28 +1081,36 @@ impl Dispatcher {
         // guard, so that a delay due to throttling doesn't result
         // in a delay of shutdown
         let path_config = self.path_config.borrow();
-        if let Some(throttle) = &path_config.max_message_rate {
-            loop {
-                let result = throttle
-                    .throttle(format!("{}-message-rate", self.name))
-                    .await
-                    .context("apply max_message_rate throttle")?;
+        let num_throttles = if path_config.max_message_rate.is_some() {
+            1
+        } else {
+            0
+        } + path_config.additional_message_rate_throttles.len();
+        if num_throttles > 0 {
+            let mut throttles = Vec::with_capacity(num_throttles);
+            let message_rate_name;
 
-                if let Some(delay) = result.retry_after {
-                    if delay >= path_config.client_timeouts.idle_timeout {
-                        self.throttle_ready_queue(delay).await;
-                        return Ok(());
-                    }
-                    tracing::trace!("{} throttled message rate, sleep for {delay:?}", self.name);
-                    let mut shutdown = ShutdownSubcription::get();
-                    tokio::select! {
-                        _ = tokio::time::sleep(delay) => {},
-                        _ = shutdown.shutting_down() => {
-                            return Ok(());
-                        }
-                    };
-                } else {
-                    break;
+            if let Some(throttle) = &path_config.max_message_rate {
+                message_rate_name = format!("kumomta.max_message_rate.{}", self.name);
+                throttles.push((&message_rate_name, throttle));
+            }
+            for (key, throttle) in &path_config.additional_message_rate_throttles {
+                throttles.push((key, throttle));
+            }
+
+            // Check throttles from smallest to largest so that we avoid
+            // taking up a slot from a larger one only to hit a smaller
+            // one and not do anything useful with the larger one
+            throttles.sort_by_key(|(_, spec)| {
+                ((spec.limit as f64 / spec.period as f64) * 1_000_000.0) as u64
+            });
+
+            for (key, throttle) in throttles {
+                if !self
+                    .check_throttle(&throttle, key, key, &path_config)
+                    .await?
+                {
+                    return Ok(());
                 }
             }
         }
@@ -1389,22 +1453,23 @@ impl Dispatcher {
             return Ok(false);
         }
 
-        if self
-            .lease
-            .extend(
-                self.path_config
-                    .borrow()
-                    .client_timeouts
-                    .total_message_send_duration(),
-            )
-            .await
-            .is_err()
-        {
-            tracing::trace!(
-                "{}: unable to extend lease, closing out this connection",
-                self.name,
-            );
-            return Ok(false);
+        for lease in &self.leases {
+            if lease
+                .extend(
+                    self.path_config
+                        .borrow()
+                        .client_timeouts
+                        .total_message_send_duration(),
+                )
+                .await
+                .is_err()
+            {
+                tracing::trace!(
+                    "{}: unable to extend lease, closing out this connection",
+                    self.name,
+                );
+                return Ok(false);
+            }
         }
 
         if self.obtain_message().await {
@@ -1455,6 +1520,12 @@ impl Dispatcher {
                     return Ok(false);
                 }
             };
+        }
+    }
+
+    async fn release_leases(&mut self) {
+        for lease in &mut self.leases {
+            lease.release().await;
         }
     }
 }

--- a/crates/throttle/src/lib.rs
+++ b/crates/throttle/src/lib.rs
@@ -59,6 +59,23 @@ impl ThrottleSpec {
     }
 }
 
+impl ThrottleSpec {
+    pub fn as_string(&self) -> Result<String, String> {
+        let period = match self.period {
+            86400 => "d",
+            3600 => "h",
+            60 => "m",
+            1 => "s",
+            _ => return Err(format!("cannot represent period {} as string", self.period)),
+        };
+        if let Some(burst) = self.max_burst {
+            return Err(format!("cannot represent max_burst {burst} as string"));
+        }
+
+        Ok(format!("{}/{period}", self.limit))
+    }
+}
+
 impl TryFrom<String> for ThrottleSpec {
     type Error = String;
     fn try_from(s: String) -> Result<Self, String> {

--- a/crates/tsa-daemon/src/http_server.rs
+++ b/crates/tsa-daemon/src/http_server.rs
@@ -328,7 +328,7 @@ async fn publish_log_v1_impl(record: JsonLogRecord) -> anyhow::Result<()> {
         .await
         .context("in tsa_load_shaping_data event")?;
 
-    let matches = shaping.match_rules(&record)?;
+    let matches = shaping.match_rules(&record).await?;
     let record_hash = sha256hex(&record)?;
 
     for m in &matches {

--- a/docs/reference/kumo/make_egress_path/additional_connection_limits.md
+++ b/docs/reference/kumo/make_egress_path/additional_connection_limits.md
@@ -1,0 +1,89 @@
+# additional_connection_limits
+
+{{since('dev')}}
+
+Specifies additional connection limit constraints that cut across the
+per-site-per-source scoping of the [connection_limit](connection_limit.md)
+option.
+
+The value is a map from the *limit name* to the desired limit.
+
+For example, you could implement a global outbound connection limit of 100
+connections like this:
+
+```lua
+kumo.on('get_egress_path_config', function(domain, source_name, site_name)
+  return kumo.make_egress_path {
+    additional_connection_limits = {
+      ['global-connection-limit'] = 100,
+    },
+  }
+end)
+```
+
+or you could set up a source-specific connection limit that is shared by all
+domains with a particular suffix match something like this, including both
+the source and your candidate domain name in the *limit name*:
+
+```lua
+local utils = require 'policy-extras.policy_utils'
+
+local LIMITS = {
+  ['.outlook.com'] = 100,
+  ['.example.com'] = 32,
+}
+
+kumo.on('get_egress_path_config', function(domain, source_name, site_name)
+  local limits = {}
+  for suffix, value in pairs(LIMITS) do
+    if utils.ends_with(domain, suffix) then
+      limits[string.format('site-limit-for-%s-%s', suffix, source)] = value
+    end
+  end
+  return kumo.make_egress_path {
+    additional_connection_limits = limits,
+  }
+end)
+```
+
+You can mix all of the above with the built-in `connection_limit`:
+
+```lua
+local utils = require 'policy-extras.policy_utils'
+
+local LIMITS = {
+  ['.outlook.com'] = 100,
+  ['.example.com'] = 32,
+}
+
+kumo.on('get_egress_path_config', function(domain, source_name, site_name)
+  local limits = {
+    -- No more than 100 connections globally
+    ['global-connection-limit'] = 100,
+  }
+  -- Apply domain+source specific limits
+  for suffix, value in pairs(LIMITS) do
+    if utils.ends_with(domain, suffix) then
+      limits[string.format('site-limit-for-%s-%s', suffix, source)] = value
+    end
+  end
+  return kumo.make_egress_path {
+    -- no more than 10 connections from a given source to this specific site
+    connection_limit = 10,
+    additional_connection_limits = limits,
+  }
+end)
+```
+
+When a connection is eligible to be established, the system will sort the
+overall set of connection limits, including the `connection_limit` limit
+option, from smallest to highest, then acquire a lease to connect in that
+order.  This minimizes the chances that we'll redundantly consume an available
+slot from the larger allocation only to trip over one of the smaller ones.
+
+!!! note
+    When choosing a name for your limit, you can select any name you like,
+    but you should avoid using the prefix `kumomta.` as that is used by
+    kumomta and you do not want to collide with its own limit names.
+
+See also [connection_limit](connection_limit.md).

--- a/docs/reference/kumo/make_egress_path/additional_message_rate_throttles.md
+++ b/docs/reference/kumo/make_egress_path/additional_message_rate_throttles.md
@@ -1,0 +1,92 @@
+# additional_message_rate_throttles
+
+{{since('dev')}}
+
+Specifies additional message rate constraints that cut across the
+per-site-per-source scoping of the [max_message_rate](max_message_rate.md)
+option.
+
+The value is a map from the *limit name* to the desired throttle spec.
+
+For example, you could implement a global outbound message rate of `4000/s`
+like this:
+
+```lua
+kumo.on('get_egress_path_config', function(domain, source_name, site_name)
+  return kumo.make_egress_path {
+    additional_message_rate_throttles = {
+      ['global-message-rate'] = '4000/s',
+    },
+  }
+end)
+```
+
+or you could set up a source-specific limit that is shared by all
+domains with a particular suffix match something like this, including both
+the source and your candidate domain name in the *limit name*:
+
+```lua
+local utils = require 'policy-extras.policy_utils'
+
+local RATES = {
+  ['.outlook.com'] = '100/s',
+  ['.example.com'] = '10/s',
+}
+
+kumo.on('get_egress_path_config', function(domain, source_name, site_name)
+  local rates = {}
+  for suffix, value in pairs(RATES) do
+    if utils.ends_with(domain, suffix) then
+      limits[string.format('site-rate-limit-for-%s-%s', suffix, source)] =
+        value
+    end
+  end
+  return kumo.make_egress_path {
+    additional_message_rate_throttles = rates,
+  }
+end)
+```
+
+You can mix all of the above with the built-in `max_message_rate`:
+
+```lua
+local utils = require 'policy-extras.policy_utils'
+
+local RATES = {
+  ['.outlook.com'] = '100/s',
+  ['.example.com'] = '10/s',
+}
+
+kumo.on('get_egress_path_config', function(domain, source_name, site_name)
+  local rates = {
+    -- No more than 4000/s connections globally
+    ['global-message-rate'] = '4000/s',
+  }
+  -- Apply domain+source specific limits
+  for suffix, value in pairs(RATES) do
+    if utils.ends_with(domain, suffix) then
+      limits[string.format('site-rate-limit-for-%s-%s', suffix, source)] =
+        value
+    end
+  end
+  return kumo.make_egress_path {
+    additional_message_rate_throttles = rates,
+    -- no more than 200/s from a given source to this specific site
+    max_message_rate = '200/s',
+  }
+end)
+```
+
+When a message is eligible to be delivered from the ready queue, the system
+will sort the overall set of rate limits, including the `max_message_rate`
+option, from smallest to highest, then check and increment each in that order.
+This minimizes the chances that we'll redundantly consume an available slot
+from the larger allocation only to trip over one of the smaller ones.
+
+!!! note
+    When choosing a name for your throttle, you can select any name you like,
+    but you should avoid using the prefix `kumomta.` as that is used by kumomta
+    and you do not want to collide with its own limit names.
+
+See also [max_message_rate](max_message_rate.md).
+


### PR DESCRIPTION
This enables shaping based on MX hostname and domain name matching rules.

At a lower level, this is supported via two new options: additional_connection_limits and additional_message_rate_throttles that allow specifying arbitrarily scoped named limits and throttles, which in addition to allowing provider-based rules in the shaping helper, allow things like global or other more esoteric scoping of constraints.