### PR TITLE
Fix compilation on macOS

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -166,7 +166,7 @@ pub async fn load_config() -> anyhow::Result<LuaConfig> {
         };
 
         let _timer = latency_timer("context-creation");
-        func.call_async(()).await?;
+        func.call_async::<_, ()>(()).await?;
     }
     LUA_COUNT.increment(1.);
 

--- a/crates/kumo-server-common/src/disk_space.rs
+++ b/crates/kumo-server-common/src/disk_space.rs
@@ -141,8 +141,8 @@ impl MonitoredPath {
         let info = nix::sys::statvfs::statvfs(&self.path)
             .with_context(|| format!("statvfs({}) failed", self.path.display()))?;
 
-        let blocks_avail = info.blocks_available();
-        let blocks_total = info.blocks();
+        let blocks_avail = info.blocks_available() as u64;
+        let blocks_total = info.blocks() as u64;
 
         let space_avail_percent =
             ((blocks_avail as f64 / blocks_total as f64) * 100.0).floor() as u8;
@@ -156,7 +156,7 @@ impl MonitoredPath {
             .unwrap()
             .set(space_avail_percent as i64);
 
-        let inodes_avail = info.files_available();
+        let inodes_avail = info.files_available() as u64;
         let inodes_total = info.files();
         let inodes_avail_percent =
             ((inodes_avail as f64 / inodes_total as f64) * 100.0).floor() as u8;

--- a/crates/proxy-server/Cargo.toml
+++ b/crates/proxy-server/Cargo.toml
@@ -13,4 +13,6 @@ libc = "0.2"
 log = "0.4"
 socksv5 = {version="0.3", default-features=false, features=["tokio"]}
 tokio = {workspace=true, features=["full", "tracing"]}
+
+[target.'cfg(target_os = "linux")'.dependencies]
 tokio-splice = "0.2"

--- a/crates/proxy-server/src/proxy_handler.rs
+++ b/crates/proxy-server/src/proxy_handler.rs
@@ -13,6 +13,7 @@ pub async fn handle_proxy_client(
     mut stream: TcpStream,
     peer_address: SocketAddr,
     timeout_duration: std::time::Duration,
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
     no_splice: bool,
 ) -> anyhow::Result<()> {
     let mut state = ClientState::None;


### PR DESCRIPTION
Fixes some minor issues that prevented `cargo check` from working on macOS, and a newish warning.

I assume keeping it compiling on macOS is a non-goal (so checking it in CI is not worth it), but these changes seem small enough that they're probably still worth it? (Would be nice for me at least.)