### PR TITLE
Amend Regex for Yahoo to suspend on both TS04 and TSS04 with the same duration of 2 hours.

### DIFF
--- a/assets/policy-extras/shaping.toml
+++ b/assets/policy-extras/shaping.toml
@@ -122,7 +122,7 @@ match=[{MXSuffix=".yahoodns.net"}]
 max_deliveries_per_connection = 20
 
 [[provider."yahoo".automation]]
-regex = "\\[TS04\\]"
+regex = "\\[TS?(S)04\\]"
 action = "Suspend"
 duration = "2 hours"
 

--- a/assets/policy-extras/shaping.toml
+++ b/assets/policy-extras/shaping.toml
@@ -122,7 +122,7 @@ match=[{MXSuffix=".yahoodns.net"}]
 max_deliveries_per_connection = 20
 
 [[provider."yahoo".automation]]
-regex = "\\[TS?(S)04\\]"
+regex = "\\[TS?S04\\]"
 action = "Suspend"
 duration = "2 hours"
 


### PR DESCRIPTION
Yahoo responds at times with DSNs such as "`421 4.7.0 [TSS04] messages from xxxx temporarily deferred due to`". This accounts for that as the general guidance for this type of response is to typically suspend delivery for 2-4 hours in the event of such a message.

This regex can be represented in multiple ways including "`\[TS?(S)04\]`", "`\[T(S|SS)04\]`", etc. As written, this was tested and validated with Golang, PCRE, PCRE2, Python, and Rust via Regex101.