### PR TITLE
A trait-based resolver API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "hickory-resolver",
  "k9 0.12.0",
  "kumo-log-types",

--- a/crates/dns-resolver/Cargo.toml
+++ b/crates/dns-resolver/Cargo.toml
@@ -18,6 +18,7 @@ unbound = ["dep:libunbound"]
 [dependencies]
 anyhow = "1.0"
 arc-swap = "1.6"
+async-trait = "0.1"
 kumo-log-types = {path="../kumo-log-types"}
 libunbound = {workspace=true, optional=true}
 lruttl = {path="../lruttl"}

--- a/crates/dns-resolver/src/lib.rs
+++ b/crates/dns-resolver/src/lib.rs
@@ -1,4 +1,3 @@
-use crate::resolver::Resolver;
 use arc_swap::ArcSwap;
 use hickory_resolver::error::ResolveResult;
 pub use hickory_resolver::proto::rr::rdata::tlsa::TLSA;
@@ -13,7 +12,8 @@ use std::net::{IpAddr, Ipv6Addr};
 use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 use std::time::Instant;
 
-pub mod resolver;
+mod resolver;
+pub use resolver::Resolver;
 
 static RESOLVER: LazyLock<ArcSwap<Resolver>> =
     LazyLock::new(|| ArcSwap::from_pointee(default_resolver()));

--- a/crates/dns-resolver/src/lib.rs
+++ b/crates/dns-resolver/src/lib.rs
@@ -14,6 +14,8 @@ use std::time::Instant;
 
 mod resolver;
 pub use resolver::Resolver;
+#[cfg(feature = "default-unbound")]
+pub use resolver::UnboundResolver;
 
 static RESOLVER: LazyLock<ArcSwap<Resolver>> =
     LazyLock::new(|| ArcSwap::from_pointee(default_resolver()));
@@ -28,11 +30,7 @@ static IP_CACHE: LazyLock<StdMutex<LruCacheWithTtl<Name, Arc<Vec<IpAddr>>>>> =
 
 #[cfg(feature = "default-unbound")]
 fn default_resolver() -> Resolver {
-    // This resolves directly against the root
-    let context = libunbound::Context::new().unwrap();
-    // and enables DNSSEC
-    context.add_builtin_trust_anchors().unwrap();
-    Resolver::Unbound(context.into_async().unwrap())
+    Resolver::Unbound(UnboundResolver::new())
 }
 
 #[cfg(not(feature = "default-unbound"))]

--- a/crates/dns-resolver/src/lib.rs
+++ b/crates/dns-resolver/src/lib.rs
@@ -30,7 +30,7 @@ static IP_CACHE: LazyLock<StdMutex<LruCacheWithTtl<Name, Arc<Vec<IpAddr>>>>> =
 
 #[cfg(feature = "default-unbound")]
 fn default_resolver() -> Resolver {
-    Resolver::Unbound(UnboundResolver::new())
+    Resolver::Unbound(UnboundResolver::new().unwrap())
 }
 
 #[cfg(not(feature = "default-unbound"))]

--- a/crates/dns-resolver/src/lib.rs
+++ b/crates/dns-resolver/src/lib.rs
@@ -1045,10 +1045,8 @@ MailExchanger {
     #[cfg(feature = "live-dns-tests")]
     #[tokio::test]
     async fn txt_lookup_gmail() {
-        let answer = get_resolver()
-            .resolve("_mta-sts.gmail.com", RecordType::TXT)
-            .await
-            .unwrap();
+        let name = Name::from_utf8("_mta-sts.gmail.com").unwrap();
+        let answer = get_resolver().resolve(name, RecordType::TXT).await.unwrap();
         k9::snapshot!(
             answer.as_txt(),
             r#"

--- a/crates/dns-resolver/src/lib.rs
+++ b/crates/dns-resolver/src/lib.rs
@@ -13,9 +13,9 @@ use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 use std::time::Instant;
 
 mod resolver;
-pub use resolver::Resolver;
 #[cfg(feature = "default-unbound")]
 pub use resolver::UnboundResolver;
+pub use resolver::{HickoryResolver, Resolver};
 
 static RESOLVER: LazyLock<ArcSwap<Resolver>> =
     LazyLock::new(|| ArcSwap::from_pointee(default_resolver()));
@@ -35,10 +35,7 @@ fn default_resolver() -> Resolver {
 
 #[cfg(not(feature = "default-unbound"))]
 fn default_resolver() -> Resolver {
-    Resolver::Tokio(
-        hickory_resolver::TokioAsyncResolver::tokio_from_system_conf()
-            .expect("Parsing /etc/resolv.conf failed"),
-    )
+    Resolver::Tokio(HickoryResolver::new().expect("Parsing /etc/resolv.conf failed"))
 }
 
 fn mx_cache_get(name: &Name) -> Option<Arc<MailExchanger>> {

--- a/crates/dns-resolver/src/resolver.rs
+++ b/crates/dns-resolver/src/resolver.rs
@@ -97,7 +97,7 @@ pub enum Resolver {
 }
 
 impl Resolver {
-    pub async fn resolve_txt<N: IntoName + TryParseIp>(&self, name: N) -> anyhow::Result<Answer> {
+    pub async fn resolve_txt(&self, name: &str) -> anyhow::Result<Answer> {
         self.resolve(name, RecordType::TXT).await
     }
 

--- a/crates/dns-resolver/src/resolver.rs
+++ b/crates/dns-resolver/src/resolver.rs
@@ -54,14 +54,14 @@ pub struct UnboundResolver {
 
 #[cfg(feature = "unbound")]
 impl UnboundResolver {
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self, libunbound::Error> {
         // This resolves directly against the root
-        let context = Context::new().unwrap();
+        let context = Context::new()?;
         // and enables DNSSEC
-        context.add_builtin_trust_anchors().unwrap();
-        Self {
-            cx: context.into_async().unwrap(),
-        }
+        context.add_builtin_trust_anchors()?;
+        Ok(Self {
+            cx: context.into_async()?,
+        })
     }
 }
 

--- a/crates/dns-resolver/src/resolver.rs
+++ b/crates/dns-resolver/src/resolver.rs
@@ -3,7 +3,7 @@ use hickory_resolver::proto::op::response_code::ResponseCode;
 #[cfg(feature = "unbound")]
 use hickory_resolver::proto::rr::DNSClass;
 use hickory_resolver::proto::rr::{RData, RecordType};
-use hickory_resolver::{IntoName, TokioAsyncResolver, TryParseIp};
+use hickory_resolver::{IntoName, Name, TokioAsyncResolver};
 #[cfg(feature = "unbound")]
 use libunbound::{AsyncContext, Context};
 use std::net::IpAddr;
@@ -98,14 +98,11 @@ pub enum Resolver {
 
 impl Resolver {
     pub async fn resolve_txt(&self, name: &str) -> anyhow::Result<Answer> {
+        let name = Name::from_utf8(name)?;
         self.resolve(name, RecordType::TXT).await
     }
 
-    pub async fn resolve<N: IntoName + TryParseIp>(
-        &self,
-        name: N,
-        rrtype: RecordType,
-    ) -> anyhow::Result<Answer> {
+    pub async fn resolve(&self, name: Name, rrtype: RecordType) -> anyhow::Result<Answer> {
         match self {
             Self::Tokio(t) => match t.inner.lookup(name, rrtype).await {
                 Ok(result) => {

--- a/crates/message/src/message.rs
+++ b/crates/message/src/message.rs
@@ -681,7 +681,7 @@ impl Message {
         let from_domain = &from[0].address.domain;
 
         struct ResolverAdapater {
-            resolver: Arc<Resolver>,
+            resolver: Arc<Box<dyn Resolver>>,
         }
 
         impl kumo_dkim::dns::Lookup for ResolverAdapater {

--- a/crates/message/src/message.rs
+++ b/crates/message/src/message.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 #[cfg(feature = "impl")]
 use config::{any_err, from_lua_value, serialize_options};
 #[cfg(feature = "impl")]
-use dns_resolver::resolver::Resolver;
+use dns_resolver::Resolver;
 #[cfg(feature = "impl")]
 use futures::future::BoxFuture;
 use futures::FutureExt;

--- a/crates/mod-dns-resolver/src/lib.rs
+++ b/crates/mod-dns-resolver/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use config::{any_err, get_or_create_sub_module, serialize_options};
-use dns_resolver::Resolver;
+use dns_resolver::{Resolver, UnboundResolver};
 use dns_resolver::{get_resolver, resolve_a_or_aaaa, MailExchanger};
 use hickory_resolver::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
 use hickory_resolver::{Name, TokioAsyncResolver};
@@ -185,7 +185,7 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
                 .context("make async resolver context")
                 .map_err(any_err)?;
 
-            dns_resolver::reconfigure_resolver(Resolver::Unbound(context));
+            dns_resolver::reconfigure_resolver(Resolver::Unbound(UnboundResolver::from(context)));
 
             Ok(())
         })?,

--- a/crates/mod-dns-resolver/src/lib.rs
+++ b/crates/mod-dns-resolver/src/lib.rs
@@ -22,7 +22,7 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
         "lookup_txt",
         lua.create_async_function(|_lua, domain: String| async move {
             let resolver = get_resolver();
-            let answer = resolver.resolve_txt(domain).await.map_err(any_err)?;
+            let answer = resolver.resolve_txt(&domain).await.map_err(any_err)?;
             Ok(answer.as_txt())
         })?,
     )?;

--- a/crates/mod-dns-resolver/src/lib.rs
+++ b/crates/mod-dns-resolver/src/lib.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
 use config::{any_err, get_or_create_sub_module, serialize_options};
-use dns_resolver::{Resolver, UnboundResolver};
-use dns_resolver::{get_resolver, resolve_a_or_aaaa, MailExchanger};
+use dns_resolver::{
+    get_resolver, resolve_a_or_aaaa, HickoryResolver, MailExchanger, UnboundResolver,
+};
 use hickory_resolver::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
 use hickory_resolver::{Name, TokioAsyncResolver};
 use mlua::{Lua, LuaSerdeExt};
@@ -127,8 +128,7 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
             }
 
             let resolver = TokioAsyncResolver::tokio(r_config, config.options);
-
-            dns_resolver::reconfigure_resolver(Resolver::Tokio(resolver.into()));
+            dns_resolver::reconfigure_resolver(HickoryResolver::from(resolver));
 
             Ok(())
         })?,
@@ -185,7 +185,7 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
                 .context("make async resolver context")
                 .map_err(any_err)?;
 
-            dns_resolver::reconfigure_resolver(Resolver::Unbound(UnboundResolver::from(context)));
+            dns_resolver::reconfigure_resolver(UnboundResolver::from(context));
 
             Ok(())
         })?,

--- a/crates/mod-dns-resolver/src/lib.rs
+++ b/crates/mod-dns-resolver/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use config::{any_err, get_or_create_sub_module, serialize_options};
-use dns_resolver::resolver::Resolver;
+use dns_resolver::Resolver;
 use dns_resolver::{get_resolver, resolve_a_or_aaaa, MailExchanger};
 use hickory_resolver::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
 use hickory_resolver::{Name, TokioAsyncResolver};

--- a/crates/mod-dns-resolver/src/lib.rs
+++ b/crates/mod-dns-resolver/src/lib.rs
@@ -128,7 +128,7 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
 
             let resolver = TokioAsyncResolver::tokio(r_config, config.options);
 
-            dns_resolver::reconfigure_resolver(Resolver::Tokio(resolver));
+            dns_resolver::reconfigure_resolver(Resolver::Tokio(resolver.into()));
 
             Ok(())
         })?,

--- a/crates/mta-sts/src/dns.rs
+++ b/crates/mta-sts/src/dns.rs
@@ -1,7 +1,7 @@
 use dns_resolver::Resolver;
 use futures::future::BoxFuture;
 use hickory_resolver::proto::rr::RecordType;
-use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::{Name, TokioAsyncResolver};
 use std::collections::BTreeMap;
 
 // <https://datatracker.ietf.org/doc/html/rfc8461>
@@ -37,6 +37,7 @@ impl Lookup for TokioAsyncResolver {
 impl Lookup for Resolver {
     fn lookup_txt<'a>(&'a self, name: &'a str) -> BoxFuture<'a, anyhow::Result<Vec<String>>> {
         Box::pin(async move {
+            let name = Name::from_utf8(name)?;
             let answer = self.resolve(name, RecordType::TXT).await?;
             Ok(answer.as_txt())
         })

--- a/crates/mta-sts/src/dns.rs
+++ b/crates/mta-sts/src/dns.rs
@@ -34,7 +34,7 @@ impl Lookup for TokioAsyncResolver {
     }
 }
 
-impl Lookup for Resolver {
+impl Lookup for Box<dyn Resolver> {
     fn lookup_txt<'a>(&'a self, name: &'a str) -> BoxFuture<'a, anyhow::Result<Vec<String>>> {
         Box::pin(async move {
             let name = Name::from_utf8(name)?;

--- a/crates/mta-sts/src/dns.rs
+++ b/crates/mta-sts/src/dns.rs
@@ -1,4 +1,4 @@
-use dns_resolver::resolver::Resolver;
+use dns_resolver::Resolver;
 use futures::future::BoxFuture;
 use hickory_resolver::proto::rr::RecordType;
 use hickory_resolver::TokioAsyncResolver;


### PR DESCRIPTION
@wez what do you think of this direction? Might make sense to review the last commit first, the rest is sort of smaller/obvious stuff to get to this. As next steps, I'd add an `impl` feature for the dns-resolver crate so that most dependencies don't need to pull in libunbound, then I can fold the crate-specific `Lookup` traits into the main `Resolver` trait.