### PR TITLE
Revert "ci: avoid deprecated syntax"

### DIFF
--- a/.woodpecker/ubuntu.yml
+++ b/.woodpecker/ubuntu.yml
@@ -174,6 +174,10 @@ steps:
       - evaluate: 'platform == "linux/aarch64" && UBUNTU_IMAGE == "ubuntu:22.04" && CI_PIPELINE_EVENT == "tag"'
     image: plugins/manifest
     failure: ignore
+    environment: &docker_manifest_env
+      # Legacy env var to prevent the plugin from throwing an error
+      # when converting an empty string to a number
+      PULLREQUEST_DRONE_PULL_REQUEST: 0
     settings: &docker_manifest_settings_tag
       <<: *docker_credentials
       target: "ghcr.io/kumocorp/kumomta-dev"
@@ -191,6 +195,8 @@ steps:
       - evaluate: 'platform == "linux/amd64" && UBUNTU_IMAGE == "ubuntu:22.04" && CI_PIPELINE_EVENT == "tag"'
     image: plugins/manifest
     failure: ignore
+    environment:
+      <<: *docker_manifest_env
     settings:
       <<: *docker_manifest_settings_tag
 
@@ -230,6 +236,8 @@ steps:
       - evaluate: 'platform == "linux/aarch64" && UBUNTU_IMAGE == "ubuntu:22.04" && CI_PIPELINE_EVENT == "push" && CI_COMMIT_BRANCH == "main"'
     image: plugins/manifest
     failure: ignore
+    environment:
+      <<: *docker_manifest_env
     settings: &docker_manifest_settings
       <<: *docker_credentials
       target: "ghcr.io/kumocorp/kumomta-dev"
@@ -247,6 +255,8 @@ steps:
       - evaluate: 'platform == "linux/amd64" && UBUNTU_IMAGE == "ubuntu:22.04" && CI_PIPELINE_EVENT == "push" && CI_COMMIT_BRANCH == "main"'
     image: plugins/manifest
     failure: ignore
+    environment:
+      <<: *docker_manifest_env
     settings:
       <<: *docker_manifest_settings
 


### PR DESCRIPTION
This reverts commit 401df300998096ab208417f4f68b75ef1fdc3d03.

The docker merge step is failing:

```
envconfig.Process: assigning PULLREQUEST_DRONE_PULL_REQUEST to Number: converting '' to type int. details: strconv.ParseInt: parsing "": invalid syntax
```

It seems that the compatibility change in
https://github.com/woodpecker-ci/woodpecker/pull/3939 isn't sufficient.

Let's see if we can still run with the environment set manually, or if we'll need to blackjack our own woodpecker plugin for this.

https://github.com/KumoCorp/kumomta/issues/309