### PR TITLE
add send_batch method to kafka mod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3980,7 +3980,6 @@ dependencies = [
  "rdkafka",
  "serde",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3974,9 +3974,12 @@ dependencies = [
  "anyhow",
  "config",
  "duration-serde",
+ "futures",
  "mlua",
  "rdkafka",
  "serde",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/mod-kafka/Cargo.toml
+++ b/crates/mod-kafka/Cargo.toml
@@ -12,4 +12,3 @@ mlua = {workspace=true, features=["vendored", "lua54", "async", "send", "seriali
 rdkafka.workspace=true
 serde.workspace=true
 tokio.workspace=true
-tracing.workspace=true

--- a/crates/mod-kafka/Cargo.toml
+++ b/crates/mod-kafka/Cargo.toml
@@ -10,3 +10,6 @@ duration-serde = {path="../duration-serde"}
 mlua = {workspace=true, features=["vendored", "lua54", "async", "send", "serialize"]}
 rdkafka = {workspace=true}
 serde = {workspace=true}
+futures = {workspace=true}
+tokio = {workspace=true, features=["full"]}
+tracing = {workspace=true}

--- a/crates/mod-kafka/Cargo.toml
+++ b/crates/mod-kafka/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = {workspace=true}
+anyhow.workspace=true
 config = {path="../config"}
 duration-serde = {path="../duration-serde"}
+futures.workspace=true
 mlua = {workspace=true, features=["vendored", "lua54", "async", "send", "serialize"]}
-rdkafka = {workspace=true}
-serde = {workspace=true}
-futures = {workspace=true}
-tokio = {workspace=true, features=["full"]}
-tracing = {workspace=true}
+rdkafka.workspace=true
+serde.workspace=true
+tokio.workspace=true
+tracing.workspace=true

--- a/docs/reference/kumo.kafka/_index.md
+++ b/docs/reference/kumo.kafka/_index.md
@@ -1,4 +1,4 @@
-# Module `kumo.amqp`
+# Module `kumo.kafka`
 
 This module provides Apache Kafka client functionality.
 

--- a/docs/reference/kumo.kafka/build_producer.md
+++ b/docs/reference/kumo.kafka/build_producer.md
@@ -40,6 +40,43 @@ producer:send {
 }
 ```
 
+### client:send_batch({PARAMS})
+
+{{ since('dev') }}
+
+Sends a batch of messages. `PARAMS` is a table of object style table with the
+following keys:
+
+* `topic` - required string; the name of the queue to which to send the message
+* `payload` - required string; the message to send
+* `timeout` - how long to wait for a response.
+
+The result from send_batch is a tuple of tables: local failed_items, errors = producer:send_batch(...).
+
+```lua
+local producer = kumo.kafka.build_producer {
+  ['bootstrap.servers'] = 'localhost:9092',
+}
+
+local failed_items, errors = producer:send_batch {{
+  topic = 'my.topic',
+  payload = 'payload 1',
+  timeout = '1 minute',
+},
+{
+  topic = 'my.other.topic',
+  payload = 'payload 2',
+  timeout = '1 minute',
+}}
+if #failed_items > 0 then
+   -- some items failed
+   for i, item_idx in ipairs(failed_items) do
+      local error = errors[i]
+      print(string.format("item idx %d failed: %s", item_idx, error))
+   end
+end
+```
+
 ### client:close()
 
 {{since('2024.09.02-c5476b89')}}


### PR DESCRIPTION
Add a new method to the kafka mod to also send with rdkafka's internal batching. The return is a bit strange because I couldn't figure out how to send the failed indexes as LuaError that could then be used in the lua part if it was caught with a pcall...