### PR TITLE
Add unmask to deb postinst

### DIFF
--- a/assets/build-deb.sh
+++ b/assets/build-deb.sh
@@ -77,6 +77,9 @@ if [ "\$1" = "configure" ]; then
     fi
 
     if [ -x "/usr/bin/deb-systemd-helper" ]; then
+      deb-systemd-helper unmask kumomta.service >/dev/null
+      deb-systemd-helper unmask kumo-tsa-daemon.service >/dev/null
+
       deb-systemd-helper enable kumomta.service >/dev/null
       deb-systemd-helper enable kumo-tsa-daemon.service >/dev/null
     fi


### PR DESCRIPTION
add unmask to enable switching between installs of kumomta and kumomta-dev and avoid: 
Failed to restart kumomta.service: Unit kumomta.service is masked.
Failed to restart kumo-tsa-daemon.service: Unit kumo-tsa-daemon.service is masked.

Also should the Conflicts field be changed to mail-transport-agent like described in the debian doc for mta? https://www.debian.org/doc/debian-policy/ch-customized-programs.html#mail-transport-delivery-and-user-agents