### PR TITLE
Modify `kcli` command example to match required arguments

### DIFF
--- a/docs/faq/flush_queue.md
+++ b/docs/faq/flush_queue.md
@@ -6,7 +6,7 @@ You can use `kcli rebind` for this; the following will flush `example.com` for a
 tenant/campaigns:
 
 ```console
-$ kcli rebind --domain example.com --always-flush
+$ kcli rebind --reason "Cleaning up a bad send" --domain example.com --always-flush
 ```
 
 `kcli rebind` re-evaluates the queue for messages in matching queues. In the


### PR DESCRIPTION
When executing the `kcli rebind` command, `--reason` is a [required argument](https://docs.kumomta.com/reference/rapidoc/?h=api#post-/api/admin/rebind/v1).

Running the command without a "reason" causes it to fail with an error message.

This copy edit to the documentation aligns the example command with its expected input.



