### PR TITLE
Complete the missing part of the command

### DIFF
--- a/docs/userguide/clustering/scaling.md
+++ b/docs/userguide/clustering/scaling.md
@@ -29,7 +29,7 @@ When a node needs to come offline the following steps can be used:
 1. Call the [rebind](https://docs.kumomta.com/reference/rapidoc/#post-/api/admin/rebind/v1) endpoint of the KumoMTA API to redirect all messages back to the load balancer. In the following example the load balancer is an IP literal in square brackets, a hostname can be used without the square brackets:
 
     ```bash
-        rebind --everything --set 'routing_domain=[192.168.1.100]'
+    kcli rebind --reason="Your reason here" --everything --set 'routing_domain=[192.168.1.100]' 
     ```
 
 1. Monitor the [metrics](https://docs.kumomta.com/reference/http/metrics.json/) API endpoint to determine when the node's queues are empty, you can then shut down the node.


### PR DESCRIPTION
I think it'd be helpful to also include over what protocol the rebind actually sends messages back into the queue. 

* Is the rebind talking through the load balancer over the same protocol that the messages was relayed to it ie: http or smtp
* Is there a special means in which it's communicating with the other server or does this command require additional authentication in order to communicate with the server on the other side of the load balancer?

This info might already be available and I just need to rtfm, in which case I'd want to link to that particular doc as well over here. 