### PR TITLE
Remove Docker compose top-level version property

### DIFF
--- a/examples/docker-swarm/compose.yaml
+++ b/examples/docker-swarm/compose.yaml
@@ -1,5 +1,3 @@
----
-version: "3.8"
 services:
   kumod:
     # use the latest build from `main`

--- a/examples/single-node-docker/compose.yaml
+++ b/examples/single-node-docker/compose.yaml
@@ -1,5 +1,3 @@
----
-version: "3"
 services:
   kumod:
     container_name: kumod


### PR DESCRIPTION
A warning message is displayed that the [version element is obsolete](https://docs.docker.com/reference/compose-file/version-and-name/) and should be removed.