### PR TITLE
Clarify example of log format `template` usage for customization

### DIFF
--- a/docs/userguide/configuration/logging.md
+++ b/docs/userguide/configuration/logging.md
@@ -95,7 +95,13 @@ If a non-JSON format is needed for the logs, the *template* option can be used:
 ```lua
 kumo.configure_local_logs {
   -- ..
-  template = [[{{type}} id={{ id }}, from={{ sender }} code={{ code }} age={{ timestamp - created }}]],
+  per_record = {
+    Bounce = {
+      -- Instead of logging the json record, evaluate this
+      -- template string and log the result.
+      template = [[Bounce! id={{ id }}, from={{ sender }} code={{ code }} age={{ timestamp - created }}]],
+    },
+  }
 }
 ```
 {% endraw %}


### PR DESCRIPTION
The documentation for configuring logging shows an example of using the Mini Jinja templating engine to format a log record using a `template` parameter:

```lua
kumo.configure_local_logs {
  -- ..
  template = [[{{type}} id={{ id }}, from={{ sender }} code={{ code }} age={{ timestamp - created }}]],
}
```

In its current context, the above example will fail with an error message while parsing `init.lua`:

```
problem initializing: call init callback: deserialize error: unknown field `template`
```

The correct usage is to nest the template format string _within_ the `per_record` parameter as shown below:

```lua
kumo.configure_local_logs {
  log_dir = '/var/log/kumomta',
  max_segment_duration = '1 seconds',

  per_record = {
    Bounce = {
      -- Instead of logging the json record, evaluate this
      -- template string and log the result.
      template = [[Bounce! id={{ id }}, from={{ sender }} code={{ code }} age={{ timestamp - created }}]],
    },
  },
}
```

This pull request updates the KumoMTA documentation with this nuance.