### PR TITLE
Adding shaping rules for Yahoo deferral codes TSS05, IPTS04 and IPTS0…

### DIFF
--- a/assets/community/shaping.toml
+++ b/assets/community/shaping.toml
@@ -77,6 +77,27 @@ trigger = {Threshold="2/hr"}
 action = "Suspend"
 duration = "2 hours"
 
+# 421 4.7.0 [TSS05] Messages from a.b.c.d temporarily deferred due to user complaints
+[["yahoo.com".automation]]
+regex = "421 4\\.7\\.0 \\[TSS05\\]"
+trigger = {Threshold="2/hr"}
+action = "Suspend"
+duration = "4 hours"
+
+# 421 [IPTS04] Messages from a.b.c.d temporarily deferred due to user complaints
+[["yahoo.com".automation]]
+regex = "421 \\[IPTS04\\]"
+trigger = {Threshold="2/hr"}
+action = "Suspend"
+duration = "2 hours"
+
+# 421 [IPTS05] Messages from a.b.c.d temporarily deferred due to user complaints
+[["yahoo.com".automation]]
+regex = "421 \\[IPTS05\\]"
+trigger = {Threshold="2/hr"}
+action = "Suspend"
+duration = "4 hours"
+
 # The sending IP is listed on a Spamhaus blacklist
 [["yahoo.com".automation]]
 regex = "553 5\\.7\\.1 \\[BL"


### PR DESCRIPTION
…5 in addition to existing TSS04 rule

Yahoo confirmed these four should all be treated similarly.

Examples:

```
421 4.7.0 [TSS05] Messages from a.b.c.d temporarily deferred due to unexpected volume or user complaints - 4.16.55.1; see https://postmaster.yahooinc.com/error-codes

421 [IPTS04] Messages from a.b.c.d temporarily deferred due to unexpected volume or user complaints - 4.16.55.1; see https://postmaster.yahooinc.com/error-codes

421 [IPTS05] Messages from a.b.c.d temporarily deferred due to unexpected volume or user complaints - 4.16.55.1; see https://postmaster.yahooinc.com/error-codes
```