### PR TITLE
Remove duplicate gmail automation rule

### DIFF
--- a/assets/community/shaping.toml
+++ b/assets/community/shaping.toml
@@ -30,12 +30,6 @@
 
 #===== GMAIL
 [["gmail.com".automation]]
-regex = "Our system has detected an unusual rate"
-trigger = {Threshold="2/hr"}
-action = {SetConfig={name="max_message_rate", value="1/minute"}}
-duration = "30m"
-
-[["gmail.com".automation]]
 regex = "Our system has detected that this message"
 trigger = {Threshold="5/hr"}
 action = "Suspend"


### PR DESCRIPTION
"gmail.com".automation --> regex = "Our system has detected an unusual rate"   

This item is repeated, although it will be override .

The reason for keeping the second one is to better protect ip reputation.