### PR TITLE
Update user guide to replace 'log_fbl' with 'log_arf' in example

### DIFF
--- a/docs/userguide/configuration/domains.md
+++ b/docs/userguide/configuration/domains.md
@@ -122,7 +122,7 @@ kumo.on('get_listener_domain', function(domain, listener, conn_meta)
     return kumo.make_listener_domain {
       relay_to = true,
       log_oob = true,
-      log_fbl = true,
+      log_arf = true,
     }
   end
 end)


### PR DESCRIPTION
This fixes a small typo I stumbled on, according the API reference this should be `log_arf`