### PR TITLE
add lookup_ptr

### DIFF
--- a/assets/run-lua-test
+++ b/assets/run-lua-test
@@ -36,6 +36,7 @@ test_module 'policy-extras.sources'
 test_module 'policy-extras.typing'
 
 dofile "crates/mod-memoize/test.lua"
+dofile "crates/mod-dns-resolver/test-dns-ptr.lua"
 
 end)
 EOT

--- a/crates/integration-tests/dns-ptr.lua
+++ b/crates/integration-tests/dns-ptr.lua
@@ -12,9 +12,7 @@ end
 -- check if we're able to resolve back to localhost
 local ok, a = pcall(kumo.dns.lookup_ptr, '127.0.0.1')
 assert(ok, 'expected localhost for 127.0.0.1 ptr')
-if ok then
-  assert(contains(a, 'localhost.'), 'expected localhost.')
-end
+assert(contains(a, 'localhost.'), 'expected localhost.')
 
 -- see if we're able to do resolve for ipv6
 local ok, a = pcall(kumo.dns.lookup_ptr, '::1')

--- a/crates/integration-tests/dns-ptr.lua
+++ b/crates/integration-tests/dns-ptr.lua
@@ -19,9 +19,7 @@ end
 -- see if we're able to do resolve for ipv6
 local ok, a = pcall(kumo.dns.lookup_ptr, '::1')
 assert(ok, 'expected localhost for ::1 ptr')
-if ok then
-  assert(contains(a, 'localhost.'), 'expected localhost.')
-end
+assert(contains(a, 'localhost.'), 'expected localhost.')
 
 local ok, a = pcall(kumo.dns.lookup_ptr, '::2')
 assert(not ok, '::2 should not have ptr')

--- a/crates/integration-tests/dns-ptr.lua
+++ b/crates/integration-tests/dns-ptr.lua
@@ -1,0 +1,28 @@
+local kumo = require 'kumo'
+
+local function contains(list, t)
+    for key, value in pairs(list) do
+        if value == t then
+            return true
+        end
+    end
+    return false
+end
+
+-- check if we're able to resolve back to localhost
+local ok, a = pcall(kumo.dns.lookup_ptr, '127.0.0.1')
+assert(ok, 'expected localhost for 127.0.0.1 ptr')
+if ok then
+  assert(contains(a, 'localhost.'), 'expected localhost.')
+end
+
+-- see if we're able to do resolve for ipv6
+local ok, a = pcall(kumo.dns.lookup_ptr, '::1')
+assert(ok, 'expected localhost for ::1 ptr')
+if ok then
+  assert(contains(a, 'localhost.'), 'expected localhost.')
+end
+
+local ok, a = pcall(kumo.dns.lookup_ptr, '::2')
+assert(not ok, '::2 should not have ptr')
+assert(string.find(tostring(a), 'no records found for Query') ~= nil, 'expected "no records found for Query"')

--- a/crates/mod-dns-resolver/test-dns-ptr.lua
+++ b/crates/mod-dns-resolver/test-dns-ptr.lua
@@ -1,5 +1,17 @@
 local kumo = require 'kumo'
 
+local zones = {
+  [[
+$ORIGIN 0.0.127.in-addr.arpa.
+1 30 IN PTR localhost.
+  ]],
+  [[
+$ORIGIN 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.
+@ 30 IN PTR localhost.
+  ]],
+}
+kumo.dns.configure_test_resolver(zones)
+
 local function contains(list, t)
     for key, value in pairs(list) do
         if value == t then
@@ -18,7 +30,3 @@ assert(contains(a, 'localhost.'), 'expected localhost.')
 local ok, a = pcall(kumo.dns.lookup_ptr, '::1')
 assert(ok, 'expected localhost for ::1 ptr')
 assert(contains(a, 'localhost.'), 'expected localhost.')
-
-local ok, a = pcall(kumo.dns.lookup_ptr, '::2')
-assert(not ok, '::2 should not have ptr')
-assert(string.find(tostring(a), 'no records found for Query') ~= nil, 'expected "no records found for Query"')

--- a/crates/mod-dns-resolver/test-dns-ptr.lua
+++ b/crates/mod-dns-resolver/test-dns-ptr.lua
@@ -13,12 +13,12 @@ $ORIGIN 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa
 kumo.dns.configure_test_resolver(zones)
 
 local function contains(list, t)
-    for key, value in pairs(list) do
-        if value == t then
-            return true
-        end
+  for key, value in pairs(list) do
+    if value == t then
+      return true
     end
-    return false
+  end
+  return false
 end
 
 -- check if we're able to resolve back to localhost

--- a/docs/reference/kumo.dns/lookup_ptr.md
+++ b/docs/reference/kumo.dns/lookup_ptr.md
@@ -8,7 +8,7 @@ Resolve PTR records for the requested `IP`.
 
 Raises an error if there was an issue resolving the record.
 
-Returns a lua array-style table with the list of A records returned from DNS.
+Returns a lua array-style table with the list of PTR records returned from DNS.  The table may be empty.
 
 ```lua
 local ok, records = pcall(kumo.dns.lookup_ptr, '127.0.0.1')

--- a/docs/reference/kumo.dns/lookup_ptr.md
+++ b/docs/reference/kumo.dns/lookup_ptr.md
@@ -6,7 +6,7 @@ kumo.dns.lookup_ptr(IP)
 
 Resolve PTR records for the requested `IP`.
 
-Raises an error if the domain doesn't exist.
+Raises an error if there was an issue resolving the record.
 
 Returns a lua array-style table with the list of A records returned from DNS.
 

--- a/docs/reference/kumo.dns/lookup_ptr.md
+++ b/docs/reference/kumo.dns/lookup_ptr.md
@@ -1,0 +1,20 @@
+# lookup_ptr
+
+```lua
+kumo.dns.lookup_ptr(IP)
+```
+
+Resolve PTR records for the requested `IP`.
+
+Raises an error if the domain doesn't exist.
+
+Returns a lua array-style table with the list of A records returned from DNS.
+
+```lua
+local ok, records = pcall(kumo.dns.lookup_ptr, '127.0.0.1')
+if ok then
+  for _, a in pairs(records) do
+    print(a)
+  end
+end
+```


### PR DESCRIPTION
Adding a function to use through lua to query PTR records.
This can be used to match against RBLs or create blocking policies against reverse domain.
Tested against both IPv4 and IPv6