### PR TITLE
add epoch with millisec

### DIFF
--- a/assets/run-lua-test
+++ b/assets/run-lua-test
@@ -39,6 +39,7 @@ dofile "crates/mod-memoize/test.lua"
 dofile "crates/mod-dns-resolver/test-dns-ptr.lua"
 dofile "crates/mod-mpsc/test.lua"
 dofile "crates/mod-filesystem/test.lua"
+dofile "crates/mod-time/test.lua"
 
 end)
 EOT

--- a/crates/mod-time/test.lua
+++ b/crates/mod-time/test.lua
@@ -1,0 +1,9 @@
+local kumo = require 'kumo'
+
+local ms = kumo.time.epoch_millis()
+kumo.time.sleep(0.1)
+local diff = kumo.time.since_millis(ms)
+assert(
+  diff > 100 and diff < 110,
+  'expected time difference between 100 ~ 110, got ' .. diff
+)

--- a/docs/reference/kumo.time/epoch_millis.md
+++ b/docs/reference/kumo.time/epoch_millis.md
@@ -1,0 +1,9 @@
+# kumo.time.epoch_millis
+
+```lua
+kumo.time.epoch_millis()
+```
+
+{{since('dev')}}
+
+Returns current time in milliseconds elapsed since the UNIX epoch (Jan 1, 1970)

--- a/docs/reference/kumo.time/since_millis.md
+++ b/docs/reference/kumo.time/since_millis.md
@@ -1,0 +1,9 @@
+# kumo.time.since_millis
+
+```lua
+kumo.time.since_millis(EPOCH_MILLIS)
+```
+
+{{since('dev')}}
+
+Returns the time delta in milliseconds, between the provided EPOCH_MILLIS and current time.


### PR DESCRIPTION
Adding two functions

- return epoch with milliseconds 
- return the time difference between now and given epoch millisec

primary usage is to be able to track and log the time duration of given task.