### PR TITLE
adding crc32 into mod-digest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,6 +4142,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "config",
+ "crc32fast",
  "data-encoding",
  "mlua",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ cidr = {version="0.3", features=["serde", "bitstring"]}
 clap = {version="4.5", features=["derive", "wrap_help"]}
 clap-markdown = "0.1"
 colorgrad = "0.7"
+crc32fast = "1.5.0"
 criterion = "0.5"
 crossbeam-queue= "0.3"
 crossbeam-skiplist= "0.1"

--- a/assets/run-lua-test
+++ b/assets/run-lua-test
@@ -39,6 +39,7 @@ dofile "crates/mod-memoize/test.lua"
 dofile "crates/mod-dns-resolver/test-dns-ptr.lua"
 dofile "crates/mod-mpsc/test.lua"
 dofile "crates/mod-filesystem/test.lua"
+dofile "crates/mod-digest/test.lua"
 
 end)
 EOT

--- a/crates/mod-digest/Cargo.toml
+++ b/crates/mod-digest/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = {workspace=true}
 config = {path="../config"}
+crc32fast = {workspace=true}
 data-encoding = {workspace=true}
 mlua = {workspace=true, features=["serialize"]}
 ring = {workspace=true}

--- a/crates/mod-digest/test.lua
+++ b/crates/mod-digest/test.lua
@@ -1,0 +1,7 @@
+local kumo = require 'kumo'
+local crc32 = kumo.digest.crc32 'something'
+
+assert(
+  crc32.hex == '09da31fb',
+  'crc32 of "something" is 09da31fb, got ' .. crc32.hex
+)

--- a/docs/reference/kumo.digest/crc32.md
+++ b/docs/reference/kumo.digest/crc32.md
@@ -1,0 +1,21 @@
+# crc32
+
+```lua
+kumo.digest.crc32(ARGS)
+```
+
+Computes a CRC32 digest over each of the arguments in ARGS.
+
+!!!note
+    CRC32 is not a cryptographic algorithm. Use for the purpose of quick checksum sanity.
+
+You may pass multiple arguments.
+
+String arguments are intepreted as bytes and fed into the digest algorithm.
+
+Other types are first encoded as a JSON string and that string is then fed
+into the digest algorithm.
+
+The returned value is a [Digest](index.md) object representing the digest
+bytes. It has properties that can return the digest bytes or encoded in
+a number of common and useful encodings.


### PR DESCRIPTION
Adding crc32 onto digest function.
For my purpose, I wanted to be able to generate a short string representation of the execution environment.