### PR TITLE
Fix minor punctuation typo in logging doc

### DIFF
--- a/docs/userguide/configuration/logging.md
+++ b/docs/userguide/configuration/logging.md
@@ -21,8 +21,9 @@ kumo.configure_local_logs {
 For multiple log files, the `configure_local_logs` function can be called
 multiple times with different parameters.
 
+<!-- prettier-ignore -->
 !!!note
-Logs can also be published as webhooks. See the [Publishing Log Events Via Webhooks](../operation/webhooks.md) chapter.
+    Logs can also be published as webhooks. See the [Publishing Log Events Via Webhooks](../operation/webhooks.md) chapter.
 
 ## OS Considerations
 


### PR DESCRIPTION
My formatter ran against the file and changed * to _ for the italics. Let me know if that is a problem and I can fix it.