### PR TITLE
Fix up current warnings

### DIFF
--- a/crates/cidr-map/src/map.rs
+++ b/crates/cidr-map/src/map.rs
@@ -505,7 +505,7 @@ where
     }
 
     /// Iterate over all values in the map
-    pub fn iter(&self) -> Iter<V> {
+    pub fn iter(&'_ self) -> Iter<'_, V> {
         Iter::new(self)
     }
 }

--- a/crates/dkim/src/canonicalization.rs
+++ b/crates/dkim/src/canonicalization.rs
@@ -84,7 +84,7 @@ impl<'haystack> Iterator for IterLines<'haystack> {
     }
 }
 
-fn iter_lines(haystack: &[u8]) -> IterLines {
+fn iter_lines(haystack: &'_ [u8]) -> IterLines<'_> {
     static CRLF: LazyLock<Finder> = LazyLock::new(|| memchr::memmem::Finder::new("\r\n"));
     IterLines {
         haystack,

--- a/crates/kumo-prometheus/src/lib.rs
+++ b/crates/kumo-prometheus/src/lib.rs
@@ -33,7 +33,7 @@ const CHUNK_SIZE: usize = 4 * 1024;
 impl<K: Clone + MetricLabel + Send + Sync, V: AtomicCounterEntry> StreamingCollector
     for CounterRegistryInner<K, V>
 {
-    fn stream_text(&self, prefix: &Option<String>) -> BoxStream<String> {
+    fn stream_text(&'_ self, prefix: &Option<String>) -> BoxStream<'_, String> {
         /*
         # HELP tokio_total_overflow_count The number of times worker threads saturated their local queues.
         # TYPE tokio_total_overflow_count counter
@@ -94,7 +94,7 @@ impl<K: Clone + MetricLabel + Send + Sync, V: AtomicCounterEntry> StreamingColle
         .boxed()
     }
 
-    fn stream_json(&self) -> BoxStream<String> {
+    fn stream_json(&'_ self) -> BoxStream<'_, String> {
         let mut target = String::with_capacity(CHUNK_SIZE);
         target.push_str(",\n\"");
         target.push_str(self.name);

--- a/crates/kumo-prometheus/src/registry.rs
+++ b/crates/kumo-prometheus/src/registry.rs
@@ -7,9 +7,9 @@ use std::sync::{Arc, LazyLock};
 
 pub trait StreamingCollector {
     /// Stream chunks of text in prometheus text exposition format
-    fn stream_text(&self, prefix: &Option<String>) -> BoxStream<String>;
+    fn stream_text(&'_ self, prefix: &Option<String>) -> BoxStream<'_, String>;
     /// Stream chunks in our json format, as chunks of text
-    fn stream_json(&self) -> BoxStream<String>;
+    fn stream_json(&'_ self) -> BoxStream<'_, String>;
     /// Prune any stale entries from this collector
     fn prune(&self);
 }

--- a/crates/kumod/src/egress_source.rs
+++ b/crates/kumod/src/egress_source.rs
@@ -104,7 +104,7 @@ impl EgressSource {
             .map(|lookup| lookup.item)
     }
 
-    fn resolve_proxy_protocol(&self, address: SocketAddr) -> anyhow::Result<ProxyProto> {
+    fn resolve_proxy_protocol(&'_ self, address: SocketAddr) -> anyhow::Result<ProxyProto<'_>> {
         use ppp::v2::{Addresses, IPv4, IPv6};
         let source_name = &self.name;
 

--- a/crates/kumod/src/http_server/inject_v1.rs
+++ b/crates/kumod/src/http_server/inject_v1.rs
@@ -373,7 +373,7 @@ impl InjectV1Request {
         }
     }
 
-    fn compile(&self) -> anyhow::Result<Compiled> {
+    fn compile(&'_ self) -> anyhow::Result<Compiled<'_>> {
         let mut env = TemplateEngine::new();
         let mut id = 0;
 
@@ -465,7 +465,7 @@ impl InjectV1Request {
         })
     }
 
-    fn attachment_data(&self) -> anyhow::Result<Vec<MimePart>> {
+    fn attachment_data(&'_ self) -> anyhow::Result<Vec<MimePart<'_>>> {
         match &self.content {
             Content::Rfc822(_) => Ok(vec![]),
             Content::Builder { attachments, .. } => {

--- a/crates/maildir/src/lib.rs
+++ b/crates/maildir/src/lib.rs
@@ -120,7 +120,7 @@ impl MailEntry {
         Ok(())
     }
 
-    pub fn parsed(&mut self) -> Result<MimePart, MailEntryError> {
+    pub fn parsed(&'_ mut self) -> Result<MimePart<'_>, MailEntryError> {
         self.read_data()?;
         let bytes = self
             .data
@@ -130,7 +130,7 @@ impl MailEntry {
         MimePart::parse(bytes).map_err(MailEntryError::ParseError)
     }
 
-    pub fn headers(&mut self) -> Result<HeaderMap, MailEntryError> {
+    pub fn headers(&'_ mut self) -> Result<HeaderMap<'_>, MailEntryError> {
         self.read_data()?;
         let bytes = self
             .data

--- a/crates/mailparsing/src/mimepart.rs
+++ b/crates/mailparsing/src/mimepart.rs
@@ -255,7 +255,7 @@ impl<'a> MimePart<'a> {
     }
 
     /// Obtains a reference to the headers
-    pub fn headers(&self) -> &HeaderMap {
+    pub fn headers(&'_ self) -> &'_ HeaderMap<'_> {
         &self.headers
     }
 
@@ -265,13 +265,13 @@ impl<'a> MimePart<'a> {
     }
 
     /// Get the raw, transfer-encoded body
-    pub fn raw_body(&self) -> SharedString {
+    pub fn raw_body(&'_ self) -> SharedString<'_> {
         self.bytes
             .slice(self.body_offset..self.body_len.max(self.body_offset))
     }
 
     /// Decode transfer decoding and return the body
-    pub fn body(&self) -> Result<DecodedBody> {
+    pub fn body(&'_ self) -> Result<DecodedBody<'_>> {
         let info = Rfc2045Info::new(&self.headers)?;
 
         let bytes = match info.encoding {

--- a/crates/mailparsing/src/nom_utils.rs
+++ b/crates/mailparsing/src/nom_utils.rs
@@ -5,7 +5,7 @@ use std::fmt::{Debug, Write};
 pub(crate) type Span<'a> = LocatedSpan<&'a str>;
 pub(crate) type IResult<'a, A, B> = nom::IResult<A, B, ParseError<Span<'a>>>;
 
-pub fn make_span(s: &str) -> Span {
+pub fn make_span(s: &'_ str) -> Span<'_> {
     Span::new(s)
 }
 

--- a/crates/rfc5321/src/client.rs
+++ b/crates/rfc5321/src/client.rs
@@ -1017,7 +1017,7 @@ impl Drop for SmtpClient {
         }
     }
 }
-fn parse_response_line(line: &str) -> Result<ResponseLine, ClientError> {
+fn parse_response_line(line: &'_ str) -> Result<ResponseLine<'_>, ClientError> {
     if line.len() < 4 {
         return Err(ClientError::MalformedResponseLine(line.to_string()));
     }


### PR DESCRIPTION
Fix up some lifetime hiding that's causing compiler warnings. This should help compilation output look a bit cleaner.

With this we should be down to zero warnings.