### PR TITLE
Remove unnecessary derives

### DIFF
--- a/crates/kumo-spf/src/lib.rs
+++ b/crates/kumo-spf/src/lib.rs
@@ -104,7 +104,6 @@ impl SpfResult {
     }
 }
 
-#[derive(Debug, Deserialize)]
 pub struct CheckHostParams {
     /// Domain that provides the sought-after authorization information.
     ///


### PR DESCRIPTION
Spotted a couple derives that didn't look like they were used.

This struct appears to largely be used as a helper rather than in the lua code itself (from what I could tell). Removing the derives didn't seem to impact the `make test`.