### PR TITLE
Fix up match on bools

### DIFF
--- a/crates/kumo-dmarc/src/types/record.rs
+++ b/crates/kumo-dmarc/src/types/record.rs
@@ -86,9 +86,10 @@ impl FromStr for Record {
             }
         }
 
-        match policy {
-            true => Ok(new),
-            false => Err(format!("missing policy in {s:?}")),
+        if policy {
+            Ok(new)
+        } else {
+            Err(format!("missing policy in {s:?}"))
         }
     }
 }

--- a/crates/kumo-spf/src/record.rs
+++ b/crates/kumo-spf/src/record.rs
@@ -317,12 +317,13 @@ impl Directive {
             }
         };
 
-        Ok(match matched {
-            true => Some(SpfResult {
+        Ok(if matched {
+            Some(SpfResult {
                 disposition: SpfDisposition::from(self.qualifier),
                 context: format!("matched '{self}' directive"),
-            }),
-            false => None,
+            })
+        } else {
+            None
         })
     }
 }

--- a/crates/kumo-spf/src/spec.rs
+++ b/crates/kumo-spf/src/spec.rs
@@ -129,9 +129,10 @@ impl MacroSpec {
                 MacroName::LocalPart => buf.push_str(cx.local_part),
                 MacroName::SenderDomain => buf.push_str(cx.sender_domain),
                 MacroName::Domain => buf.push_str(cx.domain),
-                MacroName::ReverseDns => buf.push_str(match cx.client_ip.is_ipv4() {
-                    true => "in-addr",
-                    false => "ip6",
+                MacroName::ReverseDns => buf.push_str(if cx.client_ip.is_ipv4() {
+                    "in-addr"
+                } else {
+                    "ip6"
                 }),
                 MacroName::ClientIp => {
                     buf.write_fmt(format_args!("{}", cx.client_ip)).unwrap();

--- a/crates/kumod/src/smtp_server.rs
+++ b/crates/kumod/src/smtp_server.rs
@@ -135,9 +135,10 @@ impl Into<serde_json::Value> for LogReportDisposition {
 
 impl From<bool> for LogReportDisposition {
     fn from(v: bool) -> Self {
-        match v {
-            true => Self::LogThenRelay,
-            false => Self::Ignore,
+        if v {
+            Self::LogThenRelay
+        } else {
+            Self::Ignore
         }
     }
 }

--- a/crates/throttle/src/throttle.rs
+++ b/crates/throttle/src/throttle.rs
@@ -210,10 +210,13 @@ pub async fn throttle(
     force_local: bool,
 ) -> Result<ThrottleResult, Error> {
     match (force_local, REDIS.get()) {
-        (false, Some(cx)) => match cx.has_redis_cell {
-            true => redis_cell_throttle(&cx, key, limit, period, max_burst, quantity).await,
-            false => redis_script_throttle(&cx, key, limit, period, max_burst, quantity).await,
-        },
+        (false, Some(cx)) => {
+            if cx.has_redis_cell {
+                redis_cell_throttle(&cx, key, limit, period, max_burst, quantity).await
+            } else {
+                redis_script_throttle(&cx, key, limit, period, max_burst, quantity).await
+            }
+        }
         _ => local_throttle(key, limit, period, max_burst, quantity),
     }
 }


### PR DESCRIPTION
With Rust's `if` being an expression form, an idiomatic approach to expression conditionals (like the ternary operator in C) is to use `if` where you have a conditional output value.

The one exception you might use the `match` on bool pattern is if you want to require that both paths are checked, but in all the cases below, the `match` isn't needed for that reason.