### PR TITLE
Initial DMARC support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,8 +3263,13 @@ name = "kumo-dmarc"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "dns-resolver",
+ "hickory-resolver",
  "instant-xml",
+ "k9",
  "kumo-spf",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -3468,6 +3473,7 @@ dependencies = [
  "kumo-address",
  "kumo-api-types",
  "kumo-chrono-helper",
+ "kumo-dmarc",
  "kumo-log-types",
  "kumo-prometheus",
  "kumo-server-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,7 +3264,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dns-resolver",
- "hickory-resolver",
  "instant-xml",
  "k9",
  "kumo-spf",

--- a/crates/kumo-dmarc/Cargo.toml
+++ b/crates/kumo-dmarc/Cargo.toml
@@ -5,5 +5,12 @@ edition = "2021"
 
 [dependencies]
 chrono = {workspace=true}
+dns-resolver = {path="../dns-resolver"}
+hickory-resolver = {workspace=true}
 instant-xml = {workspace=true}
 kumo-spf = { path = "../kumo-spf" }
+serde = {workspace=true}
+
+[dev-dependencies]
+k9 = {workspace=true}
+tokio = {workspace = true, features = ["full", "tracing"]}

--- a/crates/kumo-dmarc/Cargo.toml
+++ b/crates/kumo-dmarc/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 chrono = {workspace=true}
 dns-resolver = {path="../dns-resolver"}
-hickory-resolver = {workspace=true}
 instant-xml = {workspace=true}
 kumo-spf = { path = "../kumo-spf" }
 serde = {workspace=true}

--- a/crates/kumo-dmarc/src/lib.rs
+++ b/crates/kumo-dmarc/src/lib.rs
@@ -1,3 +1,147 @@
 #![allow(dead_code)]
 
 mod types;
+
+#[cfg(test)]
+mod tests;
+
+use crate::types::record::Record;
+use crate::types::results::DmarcResultWithContext;
+use dns_resolver::Resolver;
+use hickory_resolver::proto::rr::RecordType;
+use hickory_resolver::Name;
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::time::SystemTime;
+
+pub use types::results::DmarcResult;
+
+pub struct CheckHostParams {
+    /// Domain that provides the sought-after authorization information.
+    ///
+    /// Initially, the domain portion of the "MAIL FROM" or "HELO" identity.
+    pub domain: String,
+
+    /// The "MAIL FROM" email address if available.
+    pub sender: Option<String>,
+
+    /// IP address of the SMTP client that is emitting the mail (v4 or v6).
+    pub client_ip: IpAddr,
+}
+
+impl CheckHostParams {
+    pub async fn check(self, resolver: &dyn Resolver) -> DmarcResultWithContext {
+        let Self {
+            domain,
+            sender,
+            client_ip,
+        } = self;
+
+        let sender = match sender {
+            Some(sender) => sender,
+            None => format!("postmaster@{domain}"),
+        };
+
+        match DmarcContext::new(&sender, &domain, client_ip) {
+            Ok(cx) => cx.check(resolver).await,
+            Err(result) => result,
+        }
+    }
+}
+
+struct DmarcContext<'a> {
+    pub(crate) sender: &'a str,
+    pub(crate) local_part: &'a str,
+    pub(crate) sender_domain: &'a str,
+    pub(crate) domain: &'a str,
+    pub(crate) client_ip: IpAddr,
+    pub(crate) now: SystemTime,
+}
+
+impl<'a> DmarcContext<'a> {
+    /// Create a new evaluation context.
+    ///
+    /// - `sender` is the "MAIL FROM" or "HELO" identity
+    /// - `domain` is the domain that provides the sought-after authorization information;
+    ///   initially, the domain portion of the "MAIL FROM" or "HELO" identity
+    /// - `client_ip` is the IP address of the SMTP client that is emitting the mail
+    fn new(
+        sender: &'a str,
+        domain: &'a str,
+        client_ip: IpAddr,
+    ) -> Result<Self, DmarcResultWithContext> {
+        let Some((local_part, sender_domain)) = sender.split_once('@') else {
+            return Err(DmarcResultWithContext {
+                result: DmarcResult::Fail,
+                context:
+                    "input sender parameter '{sender}' is missing @ sign to delimit local part and domain".to_owned(),
+            });
+        };
+
+        Ok(Self {
+            sender,
+            local_part,
+            sender_domain,
+            domain,
+            client_ip,
+            now: SystemTime::now(),
+        })
+    }
+
+    pub(crate) fn with_domain(&self, domain: &'a str) -> Self {
+        Self { domain, ..*self }
+    }
+
+    pub async fn check(&self, resolver: &dyn Resolver) -> DmarcResultWithContext {
+        let name = match Name::from_utf8(self.domain) {
+            Ok(name) => name,
+            Err(_) => {
+                return DmarcResultWithContext {
+                    result: DmarcResult::Fail,
+                    context: format!("invalid domain name: {}", self.domain),
+                }
+            }
+        };
+
+        let initial_txt = match resolver.resolve(name, RecordType::TXT).await {
+            Ok(answer) => {
+                if answer.records.is_empty() || answer.nxdomain {
+                    return DmarcResultWithContext {
+                        result: DmarcResult::Fail,
+                        context: format!("no DMARC records found for {}", &self.domain),
+                    };
+                } else {
+                    answer.as_txt()
+                }
+            }
+            Err(err) => {
+                return DmarcResultWithContext {
+                    result: DmarcResult::Fail,
+                    context: format!("{err}"),
+                };
+            }
+        };
+
+        // TXT records can contain all sorts of stuff, let's walk through
+        // the set that we retrieved and take the first one that parses
+        for txt in initial_txt {
+            if txt.starts_with("v=DMARC1") {
+                match Record::from_str(&txt) {
+                    Ok(record) => {
+                        return record.evaluate(self, resolver).await;
+                    }
+                    Err(err) => {
+                        return DmarcResultWithContext {
+                            result: DmarcResult::Fail,
+                            context: format!("failed to parse DMARC record: {err}"),
+                        };
+                    }
+                }
+            }
+        }
+        DmarcResultWithContext {
+            result: DmarcResult::Fail,
+            context: format!("no DMARC records found for {}", &self.domain),
+        }
+    }
+}

--- a/crates/kumo-dmarc/src/tests.rs
+++ b/crates/kumo-dmarc/src/tests.rs
@@ -1,0 +1,42 @@
+use crate::types::results::DmarcResultWithContext;
+use crate::{DmarcContext, DmarcResult};
+use dns_resolver::{Resolver, TestResolver};
+use std::net::{IpAddr, Ipv4Addr};
+
+#[tokio::test]
+async fn dmarc_all() {
+    let resolver = TestResolver::default().with_zone(EXAMPLE_COM).with_txt(
+        "example.com",
+        "v=DMARC1; p=reject; aspf=r; \
+            rua=mailto:dmarc-feedback@example.com"
+            .to_string(),
+    );
+
+    let result = evaluate_ip(Ipv4Addr::LOCALHOST, &resolver).await;
+
+    k9::assert_equal!(result.result, DmarcResult::Pass);
+    k9::assert_equal!(result.context.starts_with("Success"), true);
+}
+
+async fn evaluate_ip(
+    client_ip: impl Into<IpAddr>,
+    resolver: &dyn Resolver,
+) -> DmarcResultWithContext {
+    match DmarcContext::new("sender@example.com", "example.com", client_ip.into()) {
+        Ok(cx) => cx.check(resolver).await,
+        Err(result) => result,
+    }
+}
+
+const EXAMPLE_COM: &str = r#"; A domain with two mail servers, two hosts, and two servers
+; at the domain name
+$ORIGIN example.com.
+@       600 MX  10 mail-a
+            MX  20 mail-b
+            A   192.0.2.10
+            A   192.0.2.11
+amy         A   192.0.2.65
+bob         A   192.0.2.66
+mail-a      A   192.0.2.129
+mail-b      A   192.0.2.130
+www         CNAME example.com."#;

--- a/crates/kumo-dmarc/src/tests.rs
+++ b/crates/kumo-dmarc/src/tests.rs
@@ -1,10 +1,53 @@
 use crate::types::results::DmarcResultWithContext;
 use crate::{DmarcContext, DmarcResult};
 use dns_resolver::{Resolver, TestResolver};
+use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr};
 
 #[tokio::test]
-async fn dmarc_all() {
+async fn dmarc_dkim_relaxed_subdomain() {
+    let resolver = TestResolver::default().with_zone(EXAMPLE_COM).with_txt(
+        "sample.example.com",
+        "v=DMARC1; p=reject; adkim=r; \
+            rua=mailto:dmarc-feedback@example.com"
+            .to_string(),
+    );
+
+    let result = evaluate_ip(
+        Ipv4Addr::LOCALHOST,
+        "sample.example.com",
+        "sample.example.com",
+        Some("example.com"),
+        &resolver,
+    )
+    .await;
+
+    k9::assert_equal!(result.result, DmarcResult::Pass);
+}
+
+#[tokio::test]
+async fn dmarc_dkim_strict_subdomain() {
+    let resolver = TestResolver::default().with_zone(EXAMPLE_COM).with_txt(
+        "example.com",
+        "v=DMARC1; p=reject; adkim=s; \
+            rua=mailto:dmarc-feedback@example.com"
+            .to_string(),
+    );
+
+    let result = evaluate_ip(
+        Ipv4Addr::LOCALHOST,
+        "sample.example.com",
+        "example.com",
+        Some("example.com"),
+        &resolver,
+    )
+    .await;
+
+    k9::assert_equal!(result.result, DmarcResult::Fail);
+}
+
+#[tokio::test]
+async fn dmarc_spf_relaxed_subdomain() {
     let resolver = TestResolver::default().with_zone(EXAMPLE_COM).with_txt(
         "example.com",
         "v=DMARC1; p=reject; aspf=r; \
@@ -12,17 +55,56 @@ async fn dmarc_all() {
             .to_string(),
     );
 
-    let result = evaluate_ip(Ipv4Addr::LOCALHOST, &resolver).await;
+    let result = evaluate_ip(
+        Ipv4Addr::LOCALHOST,
+        "example.com",
+        "helper.example.com",
+        None,
+        &resolver,
+    )
+    .await;
 
     k9::assert_equal!(result.result, DmarcResult::Pass);
-    k9::assert_equal!(result.context.starts_with("Success"), true);
+}
+
+#[tokio::test]
+async fn dmarc_spf_strict_subdomain() {
+    let resolver = TestResolver::default().with_zone(EXAMPLE_COM).with_txt(
+        "example.com",
+        "v=DMARC1; p=reject; aspf=s; \
+            rua=mailto:dmarc-feedback@example.com"
+            .to_string(),
+    );
+
+    let result = evaluate_ip(
+        Ipv4Addr::LOCALHOST,
+        "example.com",
+        "helper.example.com",
+        None,
+        &resolver,
+    )
+    .await;
+
+    k9::assert_equal!(result.result, DmarcResult::Fail);
 }
 
 async fn evaluate_ip(
     client_ip: impl Into<IpAddr>,
+    from_domain: &str,
+    mail_from_domain: &str,
+    dkim_domain: Option<&str>,
     resolver: &dyn Resolver,
 ) -> DmarcResultWithContext {
-    match DmarcContext::new("sender@example.com", "example.com", client_ip.into()) {
+    let dkim = if let Some(dkim_domain) = dkim_domain {
+        let mut map = BTreeMap::new();
+        map.insert("header.d".to_string(), dkim_domain.to_string());
+
+        vec![map]
+    } else {
+        vec![]
+    };
+
+    match DmarcContext::new(from_domain, Some(mail_from_domain), client_ip.into(), &dkim) {
         Ok(cx) => cx.check(resolver).await,
         Err(result) => result,
     }
@@ -37,6 +119,7 @@ $ORIGIN example.com.
             A   192.0.2.11
 amy         A   192.0.2.65
 bob         A   192.0.2.66
+sample      A   192.0.2.67
 mail-a      A   192.0.2.129
 mail-b      A   192.0.2.130
 www         CNAME example.com."#;

--- a/crates/kumo-dmarc/src/types/format.rs
+++ b/crates/kumo-dmarc/src/types/format.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+#[derive(Debug)]
 pub enum Format {
     Afrf,
 }

--- a/crates/kumo-dmarc/src/types/record.rs
+++ b/crates/kumo-dmarc/src/types/record.rs
@@ -1,21 +1,39 @@
+use dns_resolver::Resolver;
+
 use crate::types::feedback_address::FeedbackAddress;
 use crate::types::format::Format;
 use crate::types::mode::Mode;
 use crate::types::policy::Policy;
 use crate::types::report_failure::ReportFailure;
+use crate::types::results::DmarcResultWithContext;
+use crate::{DmarcContext, DmarcResult};
 use std::str::FromStr;
 
+#[derive(Debug)]
 pub struct Record {
-    align_dkim: Mode,
-    align_spf: Mode,
+    pub align_dkim: Mode,
+    pub align_spf: Mode,
     report_failure: ReportFailure,
-    policy: Policy,
+    pub policy: Policy,
     rate: u8,
     format: Format,
     interval: u32,
     aggregate_feedback: Vec<FeedbackAddress>,
     message_failure: Vec<FeedbackAddress>,
     subdomain_policy: Policy,
+}
+
+impl Record {
+    pub(crate) async fn evaluate(
+        &self,
+        _cx: &DmarcContext<'_>,
+        _resolver: &dyn Resolver,
+    ) -> DmarcResultWithContext {
+        DmarcResultWithContext {
+            result: DmarcResult::Pass,
+            context: "Success".into(),
+        }
+    }
 }
 
 impl FromStr for Record {

--- a/crates/kumo-dmarc/src/types/results.rs
+++ b/crates/kumo-dmarc/src/types/results.rs
@@ -4,6 +4,7 @@ use crate::types::policy_override::PolicyOverrideReason;
 use instant_xml::{FromXml, ToXml};
 use kumo_spf::SpfDisposition;
 use serde::Serialize;
+use std::fmt;
 use std::net::IpAddr;
 
 #[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
@@ -56,11 +57,26 @@ pub struct DkimAuthResult {
     human_result: Option<String>,
 }
 
-#[derive(Debug, Eq, PartialEq, ToXml, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, ToXml, Serialize)]
 #[xml(scalar, rename_all = "lowercase")]
 pub enum DmarcResult {
     Pass,
     Fail,
+}
+
+impl DmarcResult {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+        }
+    }
+}
+
+impl fmt::Display for DmarcResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
 // A synthetic type to bundle the result with a reason

--- a/crates/kumo-dmarc/src/types/results.rs
+++ b/crates/kumo-dmarc/src/types/results.rs
@@ -3,6 +3,7 @@ use crate::types::policy::Policy;
 use crate::types::policy_override::PolicyOverrideReason;
 use instant_xml::{FromXml, ToXml};
 use kumo_spf::SpfDisposition;
+use serde::Serialize;
 use std::net::IpAddr;
 
 #[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
@@ -55,11 +56,19 @@ pub struct DkimAuthResult {
     human_result: Option<String>,
 }
 
-#[derive(Debug, Eq, PartialEq, ToXml)]
+#[derive(Debug, Eq, PartialEq, ToXml, Serialize)]
 #[xml(scalar, rename_all = "lowercase")]
 pub enum DmarcResult {
     Pass,
     Fail,
+}
+
+// A synthetic type to bundle the result with a reason
+#[derive(Debug, Eq, PartialEq, ToXml, Serialize)]
+#[xml(rename_all = "lowercase")]
+pub struct DmarcResultWithContext {
+    pub result: DmarcResult,
+    pub context: String,
 }
 
 #[derive(Debug, Eq, PartialEq, ToXml)]

--- a/crates/kumod/Cargo.toml
+++ b/crates/kumod/Cargo.toml
@@ -30,6 +30,7 @@ humantime.workspace = true
 kumo-address = {path="../kumo-address"}
 kumo-api-types = {path="../kumo-api-types"}
 kumo-chrono-helper = {path="../kumo-chrono-helper"}
+kumo-dmarc = {path="../kumo-dmarc"}
 kumo-log-types = {path="../kumo-log-types"}
 kumo-prometheus = {path="../kumo-prometheus"}
 kumo-server-common = {path="../kumo-server-common"}

--- a/crates/kumod/src/dmarc.rs
+++ b/crates/kumod/src/dmarc.rs
@@ -1,0 +1,87 @@
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use config::{get_or_create_sub_module, serialize_options};
+use kumo_dmarc::{CheckHostParams, DmarcResult};
+use mailparsing::AuthenticationResult;
+use message::Message;
+use mlua::{Lua, LuaSerdeExt, UserDataRef};
+use serde::Serialize;
+
+use crate::smtp_server::ConnectionMetaData;
+use crate::spf;
+
+#[derive(Debug, Serialize)]
+struct CheckHostOutput {
+    disposition: DmarcResult,
+    result: AuthenticationResult,
+}
+
+pub fn register<'lua>(lua: &'lua Lua) -> anyhow::Result<()> {
+    let dmarc_mod = get_or_create_sub_module(lua, "dmarc")?;
+
+    dmarc_mod.set(
+        "verify",
+        lua.create_async_function(
+            |lua,
+             (domain, _msg, spf_result, dkim_result, meta): (
+                String,
+                UserDataRef<Message>,
+                UserDataRef<Vec<AuthenticationResult>>,
+                UserDataRef<spf::CheckHostOutput>,
+                UserDataRef<ConnectionMetaData>,
+            )| async move {
+                let addr = meta
+                    .get_meta("received_from")
+                    .and_then(|v| SocketAddr::from_str(v.as_str()?).ok())
+                    .expect("`received_from` is always set, and always to a value representing a `SocketAddr`");
+
+                let resolver = dns_resolver::get_resolver();
+
+                let _result = CheckHostParams {
+                    domain,
+                    sender: None, //FIXME: for now set this to none
+                    client_ip: addr.ip(),
+                }
+                .check(&**resolver)
+                .await;
+
+                if (matches!(dkim_result.disposition, kumo_spf::SpfDisposition::Pass)
+                    || matches!(dkim_result.disposition, kumo_spf::SpfDisposition::Neutral))
+                    && spf_result.iter().all(|x| x.result == "PASS")
+                {
+                    Ok(lua.to_value_with(
+                        &CheckHostOutput {
+                            disposition: DmarcResult::Pass,
+                            result: AuthenticationResult {
+                                method: "dmarc".to_string(),
+                                method_version: None,
+                                result: "PASS".to_string(),
+                                reason: Some("SPF and DKIM pass".to_string()),
+                                props: BTreeMap::default(),
+                            },
+                        },
+                        serialize_options(),
+                    ))
+                } else {
+                    Ok(lua.to_value_with(
+                        &CheckHostOutput {
+                            disposition: DmarcResult::Fail,
+                            result: AuthenticationResult {
+                                method: "dmarc".to_string(),
+                                method_version: None,
+                                result: "FAIL".to_string(),
+                                reason: Some("SPF and DKIM fail".to_string()),
+                                props: BTreeMap::default(),
+                            },
+                        },
+                        serialize_options(),
+                    ))
+                }
+            },
+        )?,
+    )?;
+
+    Ok(())
+}

--- a/crates/kumod/src/main.rs
+++ b/crates/kumod/src/main.rs
@@ -23,6 +23,7 @@ pub static VALIDATE_SIG: Multiple("validate_config") -> ();
 
 mod accounting;
 mod delivery_metrics;
+mod dmarc;
 mod egress_source;
 mod http_server;
 mod logging;
@@ -333,6 +334,7 @@ async fn run(opts: Opt) -> anyhow::Result<()> {
             crate::logging::register,
             message::dkim::register,
             crate::spf::register,
+            crate::dmarc::register,
         ],
         policy: &opts.policy,
     }

--- a/crates/kumod/src/spf.rs
+++ b/crates/kumod/src/spf.rs
@@ -9,9 +9,9 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 #[derive(Debug, Serialize)]
-struct CheckHostOutput {
-    disposition: SpfDisposition,
-    result: AuthenticationResult,
+pub struct CheckHostOutput {
+    pub disposition: SpfDisposition,
+    pub result: AuthenticationResult,
 }
 
 pub fn register<'lua>(lua: &'lua Lua) -> anyhow::Result<()> {


### PR DESCRIPTION
Begin laying the groundwork for DMARC support.

Please note:
- some of this carries over from SPF support so that we can align DMARC code-wise with the structure we had before. I suspect this will change as it matures
- the only implemented logic thus far is the SPF and DKIM alignment checks.
- lua registration is in this PR, but lua testing was moved out for simplicity.
