### PR TITLE
Add support for dmarc pct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,7 +3267,7 @@ dependencies = [
  "instant-xml",
  "k9",
  "kumo-spf",
- "rand 0.9.2",
+ "rand 0.8.5",
  "serde",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,7 @@ dependencies = [
  "instant-xml",
  "k9",
  "kumo-spf",
+ "rand 0.9.2",
  "serde",
  "tokio",
 ]

--- a/crates/kumo-dmarc/Cargo.toml
+++ b/crates/kumo-dmarc/Cargo.toml
@@ -9,7 +9,7 @@ dns-resolver = {path="../dns-resolver"}
 instant-xml = {workspace=true}
 kumo-spf = { path = "../kumo-spf" }
 serde = {workspace=true}
-rand = "0.9"
+rand = {workspace=true}
 
 [dev-dependencies]
 k9 = {workspace=true}

--- a/crates/kumo-dmarc/Cargo.toml
+++ b/crates/kumo-dmarc/Cargo.toml
@@ -9,6 +9,7 @@ dns-resolver = {path="../dns-resolver"}
 instant-xml = {workspace=true}
 kumo-spf = { path = "../kumo-spf" }
 serde = {workspace=true}
+rand = "0.9"
 
 [dev-dependencies]
 k9 = {workspace=true}

--- a/crates/kumo-dmarc/src/tests.rs
+++ b/crates/kumo-dmarc/src/tests.rs
@@ -136,14 +136,14 @@ async fn dmarc_spf_strict_subdomain() {
 async fn dmarc_pct_rate() {
     let mut total_failures = 0;
 
-    for _ in 0..10000 {
-        let resolver = TestResolver::default().with_zone(EXAMPLE_COM).with_txt(
-            "example.com",
-            "v=DMARC1; p=reject; aspf=s; pct=50; \
+    let resolver = TestResolver::default().with_zone(EXAMPLE_COM).with_txt(
+        "example.com",
+        "v=DMARC1; p=reject; aspf=s; pct=50; \
                 rua=mailto:dmarc-feedback@example.com"
-                .to_string(),
-        );
+            .to_string(),
+    );
 
+    for _ in 0..10000 {
         let result = evaluate_ip(
             Ipv4Addr::LOCALHOST,
             "example.com",

--- a/crates/kumo-dmarc/src/types/record.rs
+++ b/crates/kumo-dmarc/src/types/record.rs
@@ -28,6 +28,12 @@ impl Record {
         cx: &DmarcContext<'_>,
         _resolver: &dyn Resolver,
     ) -> DmarcResultWithContext {
+        if rand::random_range(0..100) >= self.rate {
+            return DmarcResultWithContext {
+                result: DmarcResult::Pass,
+                context: "DMARC: message skipped".into(),
+            };
+        }
         match self.align_dkim {
             Mode::Relaxed => {
                 for dkim in cx.dkim {

--- a/crates/kumo-dmarc/src/types/record.rs
+++ b/crates/kumo-dmarc/src/types/record.rs
@@ -28,10 +28,10 @@ impl Record {
         cx: &DmarcContext<'_>,
         _resolver: &dyn Resolver,
     ) -> DmarcResultWithContext {
-        if rand::random_range(0..100) >= self.rate {
+        if rand::random::<u8>() % 100 >= self.rate {
             return DmarcResultWithContext {
                 result: DmarcResult::Pass,
-                context: "DMARC: message skipped".into(),
+                context: format!("sampled_out due to pct={}", self.rate),
             };
         }
         match self.align_dkim {


### PR DESCRIPTION
This adds initial support for `pct=` to the DMARC support. Currently, we pass the message with a message that it was skipped, though we may want to explore a status that lets us know the message was skipped.

Testing is fairly simple, using a large sampling test to ensure that the pct is kicking in and only testing x percent of the messages. This can fail if it finds an outlier run, which currently would lead to a spurious failure.