### PR TITLE
add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.90"
+


### PR DESCRIPTION
The latest bump to deps caused an issue where the 1.89 toolchain no longer worked. This adds a toolchain file to document the rust version required to build the codebase, which is now 1.90.