### PR TITLE
#419 - Add authentication switches to traffic-gen + docs

### DIFF
--- a/docs/userguide/performance/testing.md
+++ b/docs/userguide/performance/testing.md
@@ -26,23 +26,14 @@ For cases where accurate simulation is not feasible, KumoMTA includes a "Traffic
 $ /opt/kumomta/sbin/traffic-gen --target <your.sink.server>:25 --concurrency 20000 --message-count 100000 --body-size 100000
 ```
 
+`traffic-gen` currently supports **AUTH PLAIN** only, provide credentials with `--auth-username` and `--auth-password`, and for SMTP enable `--starttls` so credentials are exchanged over TLS. In `--http` mode the same flags are sent as HTTP Basic Auth to the inject API
+
 For additional parameters for the `traffic-gen` utility see:
 
 ```console
 $ /opt/kumomta/sbin/traffic-gen --help
 ```
 
-To test authenticated SMTP injection, supply credentials with the authentication flags. `traffic-gen` currently supports the `AUTH PLAIN` mechanism.  When authenticating you must also enable `--starttls` so the credentials are exchanged over TLS; the command will now error out if TLS is not requested or if the remote server fails to advertise STARTTLS:
-
-```console
-$ /opt/kumomta/sbin/traffic-gen --target <your.sink.server>:25 \
-    --auth plain --auth-username <USERNAME> --auth-password <PASSWORD> \
-    --starttls
-```
-
-The same username and password options can be used together with the existing
-`--http` switch; in that mode the credentials are applied as HTTP basic auth
-headers for calls to the inject API.
 
 The `traffic-gen` script is used internally by the KumoMTA team to test performance before each release.
 

--- a/docs/userguide/performance/testing.md
+++ b/docs/userguide/performance/testing.md
@@ -32,6 +32,18 @@ For additional parameters for the `traffic-gen` utility see:
 $ /opt/kumomta/sbin/traffic-gen --help
 ```
 
+To test authenticated SMTP injection, supply credentials with the authentication flags. `traffic-gen` currently supports the `AUTH PLAIN` mechanism.  When authenticating you must also enable `--starttls` so the credentials are exchanged over TLS; the command will now error out if TLS is not requested or if the remote server fails to advertise STARTTLS:
+
+```console
+$ /opt/kumomta/sbin/traffic-gen --target <your.sink.server>:25 \
+    --auth plain --auth-username <USERNAME> --auth-password <PASSWORD> \
+    --starttls
+```
+
+The same username and password options can be used together with the existing
+`--http` switch; in that mode the credentials are applied as HTTP basic auth
+headers for calls to the inject API.
+
 The `traffic-gen` script is used internally by the KumoMTA team to test performance before each release.
 
 A more advanced example is as follows:


### PR DESCRIPTION
Add a selectable authentication mechanism with username/password options, validate credential handling, and apply those credentials to both SMTP (including STARTTLS re-EHLO and AUTH PLAIN negotiation) and HTTP injection requests in traffic-gen

- cli: new `--auth` option (ValueEnum) with `plain` value, `--auth-username` and `--auth-password`.
- SMTP flow: stable EHLO domain, STARTTLS + re-EHLO per RFC 3207, check AUTH capability post-TLS, perform `AUTH PLAIN`
- New helpers in `mod smtp_auth`:
  - `require_auth_mech_in(mechs: &str, mech: AuthMechanism)`; verify server advertises requested mech
  - `do_smtp_auth(client, mech, mechs, creds)`; central dispatch for mechanism specific auth logic (currently handles PLAIN)
  Helpers are intentionally isolated to avoid impacting the HTTP path
- HTTP: uses `auth_credentials()?` for reqwest `basic_auth`
- Documented the new authentication workflow, including the requirement to pair credentials with `--starttls` and support for HTTP basic auth

Locally tested with both:
```
kumo.on('smtp_server_auth_plain', function(authz, authc, password, conn_meta)
  local password_database = {
    ['daniel'] = 'tiger',
  }
  if password == '' then
    return false
  end
  return password_database[authc] == password
end)

-- Use this to lookup and confirm a user/password credential
-- used with the http endpoint
kumo.on('http_server_validate_auth_basic', function(user, password)
  local password_database = {
    ['daniel'] = 'tiger',
  }
  if password == '' then
    return false
  end
  return password_database[user] == password
end)
```

via:

```
./target/release/traffic-gen --target http://<your.sink.server>:8000 --concurrency 1 --message-count 1 --body-size 1000 --domain example.com --domain-suffix '' --header "$(echo -e 'X-Test: a\r\n b\r\n')" --header "X-Tenant: 7006175" --auth plain --auth-username daniel --auth-password tiger --starttls --http

./target/release/traffic-gen --target <your.sink.server>:25 --concurrency 1 --message-count 1 --body-size 1000 --domain example.com --domain-suffix '' --header "$(echo -e 'X-Test: a\r\n b\r\n')" --header "X-Tenant: 7006175" --auth plain --auth-username daniel --auth-password tiger --starttls
```
and other combinations