### PR TITLE
Add a dmarc lua test, fix API

### DIFF
--- a/assets/policy-extras/mail_auth.lua
+++ b/assets/policy-extras/mail_auth.lua
@@ -98,8 +98,10 @@ function mod.check(msg, config)
 
   local dmarc_auth_result = nil
   if config.dmarc then
-    -- TODO: dmarc here
-    -- table.insert(auth_results, dmarc_auth_result)
+    local dmarc_disp = kumo.dmarc.check_msg(msg, {}, config.resolver)
+    dmarc_auth_result = dmarc_disp.result
+
+    table.insert(auth_results, dmarc_auth_result)
   end
 
   local arc_auth_result = nil
@@ -238,7 +240,8 @@ localhost 30 IN A 127.0.0.1
       .. 'smtp.mailfrom=sender@example.com; iprev=pass '
       .. 'reason="ip 127.0.0.1 <-> localhost.localdomain." '
       .. 'smtp.remote-ip=127.0.0.1; auth=none '
-      .. 'smtp.mailfrom=sender@example.com; arc=none'
+      .. 'smtp.mailfrom=sender@example.com; dmarc=permerror '
+      .. 'reason="no DMARC records found for example.com"; arc=none'
   )
 end
 

--- a/crates/kumo-dmarc/src/tests.rs
+++ b/crates/kumo-dmarc/src/tests.rs
@@ -2,10 +2,8 @@ use crate::types::results::DispositionWithContext;
 use crate::{Disposition, DmarcContext};
 use dns_resolver::{Resolver, TestResolver};
 use std::collections::BTreeMap;
-use std::net::Ipv4Addr;
 
 struct TestData<'a> {
-    client_ip: Ipv4Addr,
     from_domain: &'a str,
     mail_from_domain: &'a str,
     dkim_domains: &'a [Option<&'a str>],
@@ -25,7 +23,6 @@ async fn dmarc_dkim_relaxed_subdomain() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "sample.example.com",
         mail_from_domain: "sample.example.com",
         dkim_domains: &[Some("example.com")],
@@ -49,7 +46,6 @@ async fn dmarc_dkim_relaxed_subdomain_deep() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "a.b.c.sample.example.com",
         mail_from_domain: "a.b.c.sample.example.com",
         dkim_domains: &[Some("example.com")],
@@ -73,7 +69,6 @@ async fn dmarc_dkim_relaxed_subdomain_fail() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "sample.example.com",
         mail_from_domain: "sample.example.com",
         dkim_domains: &[Some("example.org")],
@@ -97,7 +92,6 @@ async fn dmarc_dkim_relaxed_subdomain_sp_quarantine_fail() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "sample.example.com",
         mail_from_domain: "sample.example.com",
         dkim_domains: &[Some("example.org")],
@@ -121,7 +115,6 @@ async fn dmarc_dkim_strict_subdomain() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "example.com",
         mail_from_domain: "example.com",
         dkim_domains: &[Some("example.com")],
@@ -145,7 +138,6 @@ async fn dmarc_dkim_strict_subdomain_fail() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "sample.example.com",
         mail_from_domain: "example.com",
         dkim_domains: &[Some("example.com")],
@@ -169,7 +161,6 @@ async fn dmarc_dkim_relaxed_illformed() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "example.com",
         mail_from_domain: "example.com",
         dkim_domains: &[None],
@@ -194,7 +185,6 @@ async fn dmarc_dkim_strict_illformed() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "example.com",
         mail_from_domain: "example.com",
         dkim_domains: &[None],
@@ -219,7 +209,6 @@ async fn dmarc_spf_relaxed_subdomain() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "example.com",
         mail_from_domain: "helper.example.com",
         dkim_domains: &[],
@@ -243,7 +232,6 @@ async fn dmarc_spf_relaxed_subdomain_deep() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "example.com",
         mail_from_domain: "a.b.c.helper.example.com",
         dkim_domains: &[],
@@ -267,7 +255,6 @@ async fn dmarc_spf_relaxed_subdomain_fail() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "example.com",
         mail_from_domain: "helper.example.org",
         dkim_domains: &[],
@@ -291,7 +278,6 @@ async fn dmarc_spf_strict_subdomain() {
         );
 
     let result = evaluate_ip(TestData {
-        client_ip: Ipv4Addr::LOCALHOST,
         from_domain: "example.com",
         mail_from_domain: "helper.example.com",
         dkim_domains: &[],
@@ -321,7 +307,6 @@ async fn dmarc_pct_rate() {
 
     for _ in 0..iters {
         let result = evaluate_ip(TestData {
-            client_ip: Ipv4Addr::LOCALHOST,
             from_domain: "example.com",
             mail_from_domain: "helper.example.com",
             dkim_domains: &[],
@@ -344,7 +329,6 @@ async fn dmarc_pct_rate() {
 
 async fn evaluate_ip<'a>(
     TestData {
-        client_ip,
         from_domain,
         mail_from_domain,
         dkim_domains,
@@ -364,12 +348,7 @@ async fn evaluate_ip<'a>(
         }
     }
 
-    match DmarcContext::new(
-        from_domain,
-        Some(mail_from_domain),
-        client_ip.into(),
-        &dkim_vec,
-    ) {
+    match DmarcContext::new(from_domain, Some(mail_from_domain), &dkim_vec) {
         Ok(cx) => cx.check(resolver).await,
         Err(result) => result,
     }

--- a/crates/kumod/src/dmarc.rs
+++ b/crates/kumod/src/dmarc.rs
@@ -1,13 +1,11 @@
-use crate::smtp_server::ConnectionMetaData;
-use config::{get_or_create_sub_module, serialize_options};
+use config::{any_err, get_or_create_sub_module, serialize_options};
 use kumo_dmarc::{CheckHostParams, Disposition};
 use mailparsing::AuthenticationResult;
 use message::Message;
 use mlua::{Lua, LuaSerdeExt, UserDataRef};
+use mod_dns_resolver::get_resolver_instance;
 use serde::Serialize;
 use std::collections::BTreeMap;
-use std::net::SocketAddr;
-use std::str::FromStr;
 
 #[derive(Debug, Serialize)]
 struct CheckHostOutput {
@@ -19,20 +17,15 @@ pub fn register<'lua>(lua: &'lua Lua) -> anyhow::Result<()> {
     let dmarc_mod = get_or_create_sub_module(lua, "dmarc")?;
 
     dmarc_mod.set(
-        "verify",
+        "check_msg",
         lua.create_async_function(
             |lua,
-             (msg, dkim_results, meta): (
+             (msg, dkim_results, opt_resolver_name): (
                 UserDataRef<Message>,
                 mlua::Value,
-                UserDataRef<ConnectionMetaData>,
+                Option<String>,
             )| async move {
-                let addr = meta
-                    .get_meta("received_from")
-                    .and_then(|v| SocketAddr::from_str(v.as_str()?).ok())
-                    .expect("`received_from` is always set, and always to a value representing a `SocketAddr`");
-
-                let resolver = dns_resolver::get_resolver();
+                let resolver = get_resolver_instance(&opt_resolver_name).map_err(any_err)?;
 
                 // MAIL FROM
                 let msg_sender = msg.sender();
@@ -57,7 +50,7 @@ pub fn register<'lua>(lua: &'lua Lua) -> anyhow::Result<()> {
                                 },
                             },
                             serialize_options(),
-                        ))
+                        ));
                     }
                 } else {
                     // The current implementation expects only a single RFC5322.From domain
@@ -73,43 +66,43 @@ pub fn register<'lua>(lua: &'lua Lua) -> anyhow::Result<()> {
                             },
                         },
                         serialize_options(),
-                    ))
+                    ));
                 };
 
-                let dkim_results: Vec<AuthenticationResult> = config::from_lua_value(&lua, dkim_results)?;
+                let dkim_results: Vec<AuthenticationResult> =
+                    config::from_lua_value(&lua, dkim_results)?;
 
                 let result = CheckHostParams {
                     from_domain,
                     mail_from_domain,
-                    client_ip: addr.ip(),
                     dkim: dkim_results.clone().into_iter().map(|x| x.props).collect(),
                 }
                 .check(&**resolver)
                 .await;
 
                 match result.result {
-                    Disposition::Pass |
-                    Disposition::None |
-                    Disposition::TempError |
-                    Disposition::PermError => {
-                        Ok(lua.to_value_with(
-                            &CheckHostOutput {
-                                disposition: result.result.clone(),
-                                result: AuthenticationResult {
-                                    method: "dmarc".to_string(),
-                                    method_version: None,
-                                    result: result.result.to_string().to_ascii_lowercase(),
-                                    reason: Some(result.context),
-                                    props: BTreeMap::default(),
-                                },
+                    Disposition::Pass
+                    | Disposition::None
+                    | Disposition::TempError
+                    | Disposition::PermError => Ok(lua.to_value_with(
+                        &CheckHostOutput {
+                            disposition: result.result.clone(),
+                            result: AuthenticationResult {
+                                method: "dmarc".to_string(),
+                                method_version: None,
+                                result: result.result.to_string().to_ascii_lowercase(),
+                                reason: Some(result.context),
+                                props: BTreeMap::default(),
                             },
-                            serialize_options(),
-                        ))
-                    }
-                    disp @ Disposition::Quarantine |
-                    disp @ Disposition::Reject => {
+                        },
+                        serialize_options(),
+                    )),
+                    disp @ Disposition::Quarantine | disp @ Disposition::Reject => {
                         let mut props = BTreeMap::default();
-                        props.insert("policy.published-domain-policy".to_string(), disp.to_string().to_ascii_lowercase());
+                        props.insert(
+                            "policy.published-domain-policy".to_string(),
+                            disp.to_string().to_ascii_lowercase(),
+                        );
                         Ok(lua.to_value_with(
                             &CheckHostOutput {
                                 disposition: result.result.clone(),


### PR DESCRIPTION
This PR does a few different, related changes:

- it adds a dmarc test into the new mail_auth.lua framework
- it updates the dmarc API
  - to simplify the API by removing unnecessary parameters
  - to change the name of the call to align better with other auth systems
  - and finally, to bring it inline with the new resolver API