### PR TITLE
feat: add Ubuntu 24.04 support for builds

### DIFF
--- a/.github/workflows/builder-images.yml
+++ b/.github/workflows/builder-images.yml
@@ -51,6 +51,12 @@ jobs:
             platform: linux/aarch64
             runs_on: kumo-linux-16core-arm64
           - IMAGE: "ubuntu"
+            VERSION: 24.04
+            ISARM: "ARM=1"
+            REPOARM: "-aarch64"
+            platform: linux/aarch64
+            runs_on: kumo-linux-16core-arm64
+          - IMAGE: "ubuntu"
             VERSION: 22.04
             ISARM: "ARM=1"
             REPOARM: "-aarch64"
@@ -70,6 +76,10 @@ jobs:
             runs_on: kumo-linux-16core-amd64
           - IMAGE: "rockylinux"
             VERSION: 8
+            platform: linux/amd64
+            runs_on: kumo-linux-16core-amd64
+          - IMAGE: "ubuntu"
+            VERSION: 24.04
             platform: linux/amd64
             runs_on: kumo-linux-16core-amd64
           - IMAGE: "ubuntu"

--- a/.github/workflows/kumomta.yml
+++ b/.github/workflows/kumomta.yml
@@ -73,6 +73,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - builder_image: docker://ghcr.io/kumocorp/builder-for-ubuntu:24.04
+            base_image: ubuntu:24.04
+            runs_on: kumo-linux-16core-amd64
+            arch: amd64
+            artifact_name: ubuntu_2404_amd64
+            build_docker: true
+            docker_platform: linux/amd64
+            test_containers: 1
+          - builder_image: docker://ghcr.io/kumocorp/builder-for-aarch64-ubuntu:24.04
+            base_image: ubuntu:24.04
+            runs_on: kumo-linux-16core-arm64
+            arch: aarch64
+            artifact_name: ubuntu_2404_aarch64
+            build_docker: true
+            docker_platform: linux/arm64
+            test_containers: 0
           - builder_image: docker://ghcr.io/kumocorp/builder-for-ubuntu:22.04
             base_image: ubuntu:22.04
             runs_on: kumo-linux-16core-amd64


### PR DESCRIPTION
## Summary

Add official support for Ubuntu 24.04 (Noble Numbat) LTS to the KumoMTA build pipeline. This enables building and testing KumoMTA releases on the latest Ubuntu LTS version alongside the existing 22.04 and 20.04 support.

## Changes

### Builder Images Workflow (`.github/workflows/builder-images.yml`)
- Added Ubuntu 24.04 builder image for aarch64 (ARM64) architecture
- Added Ubuntu 24.04 builder image for amd64 (x86-64) architecture

### KumoMTA Workflow (`.github/workflows/kumomta.yml`)
- Added Ubuntu 24.04 to the `build-ubuntu` job matrix for amd64
- Added Ubuntu 24.04 to the `build-ubuntu` job matrix for aarch64
- Enabled Docker image building for Ubuntu 24.04 (consistent with 22.04 configuration)

## Testing

Both new matrix entries follow the exact same configuration pattern as the existing Ubuntu 22.04 entries:
- amd64 builds with Docker image creation enabled
- aarch64 builds with container testing disabled (0 test containers)

## Motivation

Ubuntu 24.04 is the latest LTS release and is now widely adopted. Adding official build support ensures:
- Users on Ubuntu 24.04 can run KumoMTA with officially tested binaries
- The release pipeline includes Ubuntu 24.04 in its standard builds
- Feature parity across supported Ubuntu LTS versions

This pull request follows the existing configuration patterns from Ubuntu 22.04 and requires no additional changes to the build scripts or Dockerfiles.