### PR TITLE
Add DeepWiki documentation badge with auto-refresh feature to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Learn more in our [FAQ](https://docs.kumomta.com/faq/) and at [https://kumomta.c
 
 You can learn more about KumoMTA from the [Documentation](https://docs.kumomta.com/).
 
+You can also explore additional community-driven explanations and technical details on DeepWiki! [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/KumoCorp/kumomta)
+
 ## Community
 
 Real-time discussion is available on [Our Discord](https://kumomta.com/discord).


### PR DESCRIPTION
This PR adds a DeepWiki badge to the README.md file under the Documentation section.

The badge links directly to the KumoMTA DeepWiki page: 👉 https://deepwiki.com/KumoCorp/kumomta

Want auto-refresh? Add a badge in the repo's README! By including this badge, the repository automatically stays in sync with DeepWiki updates — ensuring that documentation references remain fresh and up to date for all visitors.

✅ Changes
Added DeepWiki badge:
MARKDOWN
[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/KumoCorp/kumomta) Added a short note linking to the DeepWiki documentation. Enabled auto-refresh functionality via DeepWiki badge integration.