### PR TITLE
Update community shaping.toml to use providers instead of site names

### DIFF
--- a/assets/community/shaping.toml
+++ b/assets/community/shaping.toml
@@ -192,31 +192,26 @@ trigger = {Threshold="5/hr"}
 action = "Suspend"
 duration = "1 hour"
 
-#===== orange.fr
-["orange.fr"]
-max_deliveries_per_connection = 75
-connection_limit = 2
-enable_tls = "Required"
-
-[["orange.fr".automation]]
+#===== orange
+[[provider."orange".automation]]
 regex = "Trop de connexions"
 trigger = {Threshold="2/hr"}
 action = {SetConfig={name="connection_limit", value=1}}
 duration = "1 hour"
 
-[["orange.fr".automation]]
+[[provider."orange".automation]]
 regex = "Service refuse"
 trigger = {Threshold="2/hr"}
 action = "Suspend"
 duration = "1 hour"
 
-[["orange.fr".automation]]
+[[provider."orange".automation]]
 regex = "Client host blocked for spamming issues.*http://csi.cloudmark.com/reset-request/"
 trigger = {Threshold="5/hr"}
 action = "Suspend"
 duration = "2 hour"
 
-[["orange.fr".automation]]
+[[provider."orange".automation]]
 regex = "Client host blocked for spamming issues.*spamhaus"
 trigger = {Threshold="5/hr"}
 action = "Suspend"

--- a/assets/policy-extras/shaping.toml
+++ b/assets/policy-extras/shaping.toml
@@ -200,6 +200,7 @@ max_deliveries_per_connection = 100
 match=[{MXSuffix=".orange.fr"}]
 provider_connection_limit = 2
 max_deliveries_per_connection = 100
+enable_tls = "Required"
 
 # PROVIDED DIRECTLY FROM MAILGUN FOR SENDERS WHO SMARTHOST VIA MAILGUN
 ["smtp.mailgun.com"]


### PR DESCRIPTION
This PR seeks to standardize the behavior of the traffic shaping system inside a provider instead of calling out site names individually.

The only concern I have is that the provider definitions are separate from the individual community rules.  I'm wondering if those should be in the same file or if it makes sense for them to be separated?