### PR TITLE
Avoid overflow when calculating delay

### DIFF
--- a/crates/kumod/src/queue/config.rs
+++ b/crates/kumod/src/queue/config.rs
@@ -156,7 +156,10 @@ impl QueueConfig {
     }
 
     pub fn delay_for_attempt(&self, attempt: u16) -> chrono::Duration {
-        let delay = self.retry_interval.as_secs() * 2u64.saturating_pow(attempt as u32);
+        let delay = self
+            .retry_interval
+            .as_secs()
+            .saturating_mul(2u64.saturating_pow(attempt as u32));
 
         let delay = match self.max_retry_interval.map(|d| d.as_secs()) {
             None => delay,


### PR DESCRIPTION
Ran into the following when torture testing KumoMTA.
While saturating_pow protects from overflow, subsequent multiplication may still result in overflow.
Changed that to saturating_mul to prevent such cases.

```
Feb 11 10:23:57 localhost kumod[3137095]: 2026-02-11T08:23:57.387418Z ERROR                           spoolin-13 kumo_server_common::panic: panic at crates/kumod/src/queue/config.rs:159:21 - attempt to multiply with overflow
Feb 11 10:23:57 localhost kumod[3137095]:    0: kumo_server_common::panic::register_panic_hook::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at home/kumomta/crates/kumo-server-common/src/panic.rs:9:18
Feb 11 10:23:57 localhost kumod[3137095]:    1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/alloc/src/boxed.rs:2019:9
Feb 11 10:23:57 localhost kumod[3137095]:       std::panicking::panic_with_hook
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:842:13
Feb 11 10:23:57 localhost kumod[3137095]:    2: std::panicking::panic_handler::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:700:13
Feb 11 10:23:57 localhost kumod[3137095]:    3: std::sys::backtrace::__rust_end_short_backtrace
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/sys/backtrace.rs:174:18
Feb 11 10:23:57 localhost kumod[3137095]:    4: __rustc::rust_begin_unwind
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:698:5
Feb 11 10:23:57 localhost kumod[3137095]:    5: core::panicking::panic_fmt
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/panicking.rs:80:14
Feb 11 10:23:57 localhost kumod[3137095]:    6: core::panicking::panic_const::panic_const_mul_overflow
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/panicking.rs:180:17
Feb 11 10:23:57 localhost kumod[3137095]:    7: kumod::queue::config::QueueConfig::delay_for_attempt
Feb 11 10:23:57 localhost kumod[3137095]:              at home/kumomta/crates/kumod/src/queue/config.rs:159:21
Feb 11 10:23:57 localhost kumod[3137095]:    8: kumod::queue::config::QueueConfig::infer_num_attempts
Feb 11 10:23:57 localhost kumod[3137095]:              at home/kumomta/crates/kumod/src/queue/config.rs:149:30
Feb 11 10:23:57 localhost kumod[3137095]:    9: kumod::spool::SpoolManager::update_next_due::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at home/kumomta/crates/kumod/src/spool.rs:296:50
Feb 11 10:23:57 localhost kumod[3137095]:   10: kumod::spool::SpoolManager::spool_in_thread::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at home/kumomta/crates/kumod/src/spool.rs:439:84
Feb 11 10:23:57 localhost kumod[3137095]:   11: kumod::spool::SpoolManager::start_spool::{{closure}}::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at home/kumomta/crates/kumod/src/spool.rs:594:87
Feb 11 10:23:57 localhost kumod[3137095]:   12: <core::pin::Pin<P> as core::future::future::Future>::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/future/future.rs:133:9
Feb 11 10:23:57 localhost kumod[3137095]:   13: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.44/src/instrument.rs:321:15
Feb 11 10:23:57 localhost kumod[3137095]:   14: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/core.rs:374:24
Feb 11 10:23:57 localhost kumod[3137095]:   15: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/loom/std/unsafe_cell.rs:16:9
Feb 11 10:23:57 localhost kumod[3137095]:       tokio::runtime::task::core::Core<T,S>::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/core.rs:363:30
Feb 11 10:23:57 localhost kumod[3137095]:   16: tokio::runtime::task::harness::poll_future::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/harness.rs:535:30
Feb 11 10:23:57 localhost kumod[3137095]:   17: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/panic/unwind_safe.rs:274:9
Feb 11 10:23:57 localhost kumod[3137095]:   18: std::panicking::catch_unwind::do_call
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:590:40
Feb 11 10:23:57 localhost kumod[3137095]:   19: __rust_try
Feb 11 10:23:57 localhost kumod[3137095]:   20: std::panicking::catch_unwind
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:553:19
Feb 11 10:23:57 localhost kumod[3137095]:       std::panic::catch_unwind
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panic.rs:359:14
Feb 11 10:23:57 localhost kumod[3137095]:   21: tokio::runtime::task::harness::poll_future
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/harness.rs:523:18
Feb 11 10:23:57 localhost kumod[3137095]:   22: tokio::runtime::task::harness::Harness<T,S>::poll_inner
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/harness.rs:210:27
Feb 11 10:23:57 localhost kumod[3137095]:   23: tokio::runtime::task::harness::Harness<T,S>::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/harness.rs:155:20
Feb 11 10:23:57 localhost kumod[3137095]:   24: tokio::runtime::task::raw::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/raw.rs:337:13
Feb 11 10:23:57 localhost kumod[3137095]:   25: tokio::runtime::task::raw::RawTask::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/raw.rs:267:18
Feb 11 10:23:57 localhost kumod[3137095]:   26: tokio::runtime::task::LocalNotified<S>::run
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/mod.rs:515:13
Feb 11 10:23:57 localhost kumod[3137095]:   27: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/worker.rs:643:18
Feb 11 10:23:57 localhost kumod[3137095]:   28: tokio::task::coop::with_budget
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/task/coop/mod.rs:167:5
Feb 11 10:23:57 localhost kumod[3137095]:       tokio::task::coop::budget
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/task/coop/mod.rs:133:5
Feb 11 10:23:57 localhost kumod[3137095]:       tokio::runtime::scheduler::multi_thread::worker::Context::run_task
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/worker.rs:634:9
Feb 11 10:23:57 localhost kumod[3137095]:   29: tokio::runtime::scheduler::multi_thread::worker::Context::run
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/worker.rs:567:29
Feb 11 10:23:57 localhost kumod[3137095]:   30: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/worker.rs:532:24
Feb 11 10:23:57 localhost kumod[3137095]:   31: tokio::runtime::context::scoped::Scoped<T>::set
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/context/scoped.rs:40:9
Feb 11 10:23:57 localhost kumod[3137095]:   32: tokio::runtime::context::set_scheduler::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/context.rs:176:38
Feb 11 10:23:57 localhost kumod[3137095]:   33: std::thread::local::LocalKey<T>::try_with
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/thread/local.rs:508:12
Feb 11 10:23:57 localhost kumod[3137095]:   34: std::thread::local::LocalKey<T>::with
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/thread/local.rs:472:20
Feb 11 10:23:57 localhost kumod[3137095]:   35: tokio::runtime::context::set_scheduler
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/context.rs:176:17
Feb 11 10:23:57 localhost kumod[3137095]:   36: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/worker.rs:527:9
Feb 11 10:23:57 localhost kumod[3137095]:   37: tokio::runtime::context::runtime::enter_runtime
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/context/runtime.rs:65:16
Feb 11 10:23:57 localhost kumod[3137095]:   38: tokio::runtime::scheduler::multi_thread::worker::run
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/worker.rs:519:5
Feb 11 10:23:57 localhost kumod[3137095]:   39: tokio::runtime::scheduler::multi_thread::worker::Launch::launch::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/worker.rs:485:45
Feb 11 10:23:57 localhost kumod[3137095]:   40: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/blocking/task.rs:42:21
Feb 11 10:23:57 localhost kumod[3137095]:   41: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.44/src/instrument.rs:321:15
Feb 11 10:23:57 localhost kumod[3137095]:   42: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/core.rs:374:24
Feb 11 10:23:57 localhost kumod[3137095]:   43: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/loom/std/unsafe_cell.rs:16:9
Feb 11 10:23:57 localhost kumod[3137095]:       tokio::runtime::task::core::Core<T,S>::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/core.rs:363:30
Feb 11 10:23:57 localhost kumod[3137095]:   44: tokio::runtime::task::harness::poll_future::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/harness.rs:535:30
Feb 11 10:23:57 localhost kumod[3137095]:   45: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/panic/unwind_safe.rs:274:9
Feb 11 10:23:57 localhost kumod[3137095]:   46: std::panicking::catch_unwind::do_call
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:590:40
Feb 11 10:23:57 localhost kumod[3137095]:   47: __rust_try
Feb 11 10:23:57 localhost kumod[3137095]:   48: std::panicking::catch_unwind
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:553:19
Feb 11 10:23:57 localhost kumod[3137095]:       std::panic::catch_unwind
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panic.rs:359:14
Feb 11 10:23:57 localhost kumod[3137095]:   49: tokio::runtime::task::harness::poll_future
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/harness.rs:523:18
Feb 11 10:23:57 localhost kumod[3137095]:   50: tokio::runtime::task::harness::Harness<T,S>::poll_inner
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/harness.rs:210:27
Feb 11 10:23:57 localhost kumod[3137095]:   51: tokio::runtime::task::harness::Harness<T,S>::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/harness.rs:155:20
Feb 11 10:23:57 localhost kumod[3137095]:   52: tokio::runtime::task::raw::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/raw.rs:337:13
Feb 11 10:23:57 localhost kumod[3137095]:   53: tokio::runtime::task::raw::RawTask::poll
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/raw.rs:267:18
Feb 11 10:23:57 localhost kumod[3137095]:   54: tokio::runtime::task::UnownedTask<S>::run
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/task/mod.rs:552:13
Feb 11 10:23:57 localhost kumod[3137095]:   55: tokio::runtime::blocking::pool::Task::run
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/blocking/pool.rs:161:19
Feb 11 10:23:57 localhost kumod[3137095]:   56: tokio::runtime::blocking::pool::Inner::run
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/blocking/pool.rs:516:22
Feb 11 10:23:57 localhost kumod[3137095]:   57: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/blocking/pool.rs:474:47
Feb 11 10:23:57 localhost kumod[3137095]:   58: std::sys::backtrace::__rust_begin_short_backtrace
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/sys/backtrace.rs:158:18
Feb 11 10:23:57 localhost kumod[3137095]:   59: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/thread/mod.rs:562:17
Feb 11 10:23:57 localhost kumod[3137095]:   60: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/panic/unwind_safe.rs:274:9
Feb 11 10:23:57 localhost kumod[3137095]:   61: std::panicking::catch_unwind::do_call
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:590:40
Feb 11 10:23:57 localhost kumod[3137095]:   62: __rust_try
Feb 11 10:23:57 localhost kumod[3137095]:   63: std::panicking::catch_unwind
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:553:19
Feb 11 10:23:57 localhost kumod[3137095]:       std::panic::catch_unwind
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panic.rs:359:14
Feb 11 10:23:57 localhost kumod[3137095]:       std::thread::Builder::spawn_unchecked_::{{closure}}
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/thread/mod.rs:560:30
Feb 11 10:23:57 localhost kumod[3137095]:   64: core::ops::function::FnOnce::call_once{{vtable.shim}}
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/ops/function.rs:250:5
Feb 11 10:23:57 localhost kumod[3137095]:   65: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/alloc/src/boxed.rs:2005:9
Feb 11 10:23:57 localhost kumod[3137095]:       std::sys::thread::unix::Thread::new::thread_start
Feb 11 10:23:57 localhost kumod[3137095]:              at rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/sys/thread/unix.rs:126:17
Feb 11 10:23:57 localhost kumod[3137095]:   66: start_thread
Feb 11 10:23:57 localhost kumod[3137095]:   67: __GI___clone
Feb 11 10:23:57 localhost kumod[3137095]: thread 'spoolin-13' (3137847) panicked at crates/kumod/src/queue/config.rs:159:21:
Feb 11 10:23:57 localhost kumod[3137095]: attempt to multiply with overflow
Feb 11 10:23:57 localhost kumod[3137095]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```