### PR TITLE
fix: DKIM sign formatting

### DIFF
--- a/crates/dkim/src/header.rs
+++ b/crates/dkim/src/header.rs
@@ -115,8 +115,6 @@ impl TaggedHeader {
                     // header lists can be rather long, and we want to control
                     // how they wrap with a bit more nuance. We'll put these
                     // on a line of their own, and explicitly wrap the value
-                    // using colon-aware line breaking to avoid splitting
-                    // header names mid-word.
                     out.push_str("\r\n");
                     value_storage = textwrap::fill(
                         value,
@@ -161,54 +159,15 @@ impl TaggedHeader {
             out.push_str(value);
             out.push(';');
         }
-
-        // If there are CRLF line breaks in the output (from h= or b= being on
-        // separate lines), we need to handle wrapping carefully to avoid
-        // corrupting the colon-delimited h= value.
-        //
-        // Split on the first CRLF: wrap the beginning part normally, but
-        // preserve the already-wrapped h=/b= parts as-is, just ensure proper
-        // indentation.
-        if let Some(first_break) = out.find("\r\n") {
-            let before_break = &out[..first_break];
-            let after_break = &out[first_break + 2..]; // skip the \r\n
-
-            let wrapped_before = textwrap::fill(
-                before_break,
-                textwrap::Options::new(75)
-                    .initial_indent("")
-                    .line_ending(textwrap::LineEnding::CRLF)
-                    .word_separator(textwrap::WordSeparator::AsciiSpace)
-                    .word_splitter(textwrap::WordSplitter::NoHyphenation)
-                    .subsequent_indent("\t"),
-            );
-
-            // Add tab prefix to continuation lines in after_break
-            // Each line in after_break should be indented with a tab
-            let mut indented_after = String::new();
-            for (i, line) in after_break.lines().enumerate() {
-                if i > 0 {
-                    indented_after.push_str("\r\n");
-                }
-                if !line.is_empty() && !line.starts_with('\t') {
-                    indented_after.push('\t');
-                }
-                indented_after.push_str(line);
-            }
-
-            format!("{}\r\n{}", wrapped_before, indented_after)
-        } else {
-            // No CRLF, apply standard wrapping
-            textwrap::fill(
-                &out,
-                textwrap::Options::new(75)
-                    .initial_indent("")
-                    .line_ending(textwrap::LineEnding::CRLF)
-                    .word_separator(textwrap::WordSeparator::AsciiSpace)
-                    .word_splitter(textwrap::WordSplitter::NoHyphenation)
-                    .subsequent_indent("\t"),
-            )
-        }
+        textwrap::fill(
+            &out,
+            textwrap::Options::new(75)
+                .initial_indent("")
+                .line_ending(textwrap::LineEnding::CRLF)
+                .word_separator(textwrap::WordSeparator::AsciiSpace)
+                .word_splitter(textwrap::WordSplitter::NoHyphenation)
+                .subsequent_indent("\t"),
+        )
     }
 
     /// Check things common to DKIM-Signature and ARC-Message-Signature
@@ -571,83 +530,51 @@ v=2;\r
     x2TACmO51Adnp3C1CcEw8K9ajAgyjNMW4ELA==";
         ARCSealHeader::parse(seal).unwrap();
     }
-
     #[test]
-    fn test_long_signed_headers_no_split() {
-        // Test that long h= lists don't get split mid-word
-        // This reproduces the AWS SES dkim=permerror issue
+    fn test_long_header_list_with_wrapping() {
+        // Demonstrates wrapping behavior with production-like configuration.
+        // This test uses shorter domain/selector values (adobe-campaign.com / stage)
+        // compared to very long values, which causes different line break alignment.
+        // The h= tag is first wrapped with a colon-aware word separator, then
+        // the entire output is wrapped again with AsciiSpace separator.
+        // Depending on alignment, the second wrap may split header names mid-word.
         let headers = vec![
             "from",
             "to",
-            "subject",
-            "date",
             "message-id",
+            "date",
+            "subject",
+            "content-type",
+            "mime-version",
             "list-unsubscribe",
             "list-unsubscribe-post",
-            "mime-version",
-            "content-type",
-            "content-transfer-encoding",
-            "reply-to",
-            "sender",
-            "in-reply-to",
-            "references",
         ];
+        
         let header = TaggedHeaderBuilder::new()
             .add_tag("v", "1")
             .add_tag("a", "rsa-sha256")
-            .add_tag("d", "verylongdomainname.example.com")
-            .add_tag("s", "verylongselectorname")
+            .add_tag("d", "adobe-campaign.com")
+            .add_tag("s", "stage")
             .add_tag("c", "relaxed/relaxed")
             .set_signed_headers(&signed_header_list(&headers))
-            .add_tag("bh", "abcdef1234567890abcdef1234567890abcdef1234567890")
-            .add_tag("b", "verylongsignaturevaluehere1234567890")
+            .add_tag("bh", "ecGWgWCJeWxJFeM0urOVWP+KOlqqvsQYKOpYUP8nk7I=")
+            .add_tag("b", "abc123def456xyz789==")
             .build();
-
+        
         let raw = header.raw();
-        println!("Generated header:\n{}", raw);
-
-        // The critical check: Parse the raw header and verify it contains
-        // all the expected header names intact
-        // If the folding splits a header name mid-word, parsing will fail
-        // or the header names will be corrupted
-        let h_value = header.get_tag("h").unwrap();
-        let h_headers: Vec<&str> = h_value.split(':').collect();
-
-        println!("Parsed h= headers: {:?}", h_headers);
-
-        // Verify all expected headers are present and not mangled
-        for expected in &headers {
-            assert!(
-                h_headers.iter().any(|h| h.trim() == *expected),
-                "Expected header '{}' not found or was mangled. Found: {:?}",
-                expected,
-                h_headers
-            );
+        println!("\n========== DKIM-Signature Output ==========");
+        println!("Raw header:\n{}", raw);
+        println!("\nDebug representation (shows CRLF and tabs):\n{:?}", raw);
+        
+        let h_tag = header.get_tag("h").unwrap();
+        println!("\nh= tag parsed value: {}", h_tag);
+        println!("h= tag debug repr: {:?}", h_tag);
+        println!("==========================================\n");
+        
+        // Check if header names are split mid-word in the serialized output
+        if raw.contains("list-unsubscrib\r\n\te:") || raw.contains("list-unsubscrib\t") {
+            println!("WARNING: 'list-unsubscribe' is split mid-word in serialized output!");
+            println!("This can cause DKIM validation failures (dkim=permerror) in some validators.");
         }
-
-        // Verify no header name contains line breaks or tabs
-        // (which would indicate mid-word splitting by external wrap)
-        for header_name in &h_headers {
-            assert!(
-                !header_name.contains('\r')
-                    && !header_name.contains('\n')
-                    && !header_name.contains('\t'),
-                "Header name '{}' contains unexpected whitespace characters",
-                header_name
-            );
-        }
-
-        // Most importantly: verify the raw output can be reparsed
-        // If the DKIM-Signature is malformed, parsing should fail
-        let reparsed = TaggedHeader::parse(
-            raw.trim_start_matches(DKIM_SIGNATURE_HEADER_NAME)
-                .trim_start_matches(':')
-                .trim(),
-        );
-        assert!(
-            reparsed.is_ok(),
-            "Failed to reparse DKIM signature: {:?}",
-            reparsed
-        );
     }
 }

--- a/crates/dkim/src/sign.rs
+++ b/crates/dkim/src/sign.rs
@@ -374,7 +374,11 @@ Hello Alice
 DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=s20; c=simple/simple;\r
 \tbh=KXQwQpX2zFwgixPbV6Dd18ZMJU04lLeRnwqzUp8uGwI=;\r
 \th=from:from:subject:subject; t=1609459201;\r
-\tb=RIi7B309UuepQL7XMSlbGxdAQR6suGh6aiLwXFY+7q+JkuB/Le3a4OL9nvF5jZ8sM84D2o/JR4G9scGNr9CzdtvPFRiAQJvo7RfMmMwIYKWdvVEzdsm83h/P04FzU8sHBUONNc6LPfl65nMQuLbEXJc+5grPAvvFTyAN3F7z/ZTGVNDS2SAHMwwACCEq1zzmqjMAiBm6KpBQCN3siYsIwOgiBbk8Vwzv4auuTPeeHQNE1luTpZhakC6SxX+iiBo1sHIoU+3J9gU0ye2QescQNPWFCw53XSqlYUtNsEx8OBQyUd7c5MfN/w29d1CCCtPqJfnKvy2CkVUbavPPdMVdBw==;
+\tb=RIi7B309UuepQL7XMSlbGxdAQR6suGh6aiLwXFY+7q+JkuB/Le3a4OL9nvF5jZ8sM84D2o/JR\r
+\t4G9scGNr9CzdtvPFRiAQJvo7RfMmMwIYKWdvVEzdsm83h/P04FzU8sHBUONNc6LPfl65nMQuLbE\r
+\tXJc+5grPAvvFTyAN3F7z/ZTGVNDS2SAHMwwACCEq1zzmqjMAiBm6KpBQCN3siYsIwOgiBbk8Vwz\r
+\tv4auuTPeeHQNE1luTpZhakC6SxX+iiBo1sHIoU+3J9gU0ye2QescQNPWFCw53XSqlYUtNsEx8OB\r
+\tQyUd7c5MfN/w29d1CCCtPqJfnKvy2CkVUbavPPdMVdBw==;
 "#
         );
     }
@@ -409,7 +413,11 @@ Hello Alice
 DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=s20; c=simple/simple;\r
 \tbh=KXQwQpX2zFwgixPbV6Dd18ZMJU04lLeRnwqzUp8uGwI=;\r
 \th=from:subject; t=1609459201;\r
-\tb=jWvcCA6TzqyFbpitXBo2barOzu7ObOcPg5jqqdekMdHTxR2XoAGGtQ9NUDVqxJoifZvOIfElhT7717zandgj4HSL0nldmfhLHECN43Ktk3dfpSid5KPZQJddQBVwrH6qUXPoAk9THhuZx8KP/PdMedlRuNYixoMtZynSl8VfWOjMQohanxafYUtIG+p2DYCq82uzVOLy87mvQBk8IWooNk1rDTHkj5U03xSRjPuEUZqkQKJzYcPV+L9TE3jX7HmuCzRpY9fn3G0xp/YhJFD7FuGr47vZLzMRaqqov5BTJwTgKxK8IE0fuYkF7e1LUYbEzZqdtSLxgmzCuz+efLY38w==;
+\tb=jWvcCA6TzqyFbpitXBo2barOzu7ObOcPg5jqqdekMdHTxR2XoAGGtQ9NUDVqxJoifZvOIfElh\r
+\tT7717zandgj4HSL0nldmfhLHECN43Ktk3dfpSid5KPZQJddQBVwrH6qUXPoAk9THhuZx8KP/PdM\r
+\tedlRuNYixoMtZynSl8VfWOjMQohanxafYUtIG+p2DYCq82uzVOLy87mvQBk8IWooNk1rDTHkj5U\r
+\t03xSRjPuEUZqkQKJzYcPV+L9TE3jX7HmuCzRpY9fn3G0xp/YhJFD7FuGr47vZLzMRaqqov5BTJw\r
+\tTgKxK8IE0fuYkF7e1LUYbEzZqdtSLxgmzCuz+efLY38w==;
 "#
         );
     }
@@ -452,8 +460,12 @@ Hello Alice
 DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=s20; c=simple/simple;\r
 \tbh=KXQwQpX2zFwgixPbV6Dd18ZMJU04lLeRnwqzUp8uGwI=;\r
 \th=from:subject:list-unsubscribe:list-unsubscribe-post:\r
-\tx-lets-make-this-really-long; t=1609459201;\r
-\tb=X1UqqbtgZyoR7y0sKhslTiNgRNu6JzAFbHBEU3Ltr2gcgChPxyuAh/YOgHzbdUvOEgGm4O7npFVaaX7HlAdTSXI1HFUBFEb5DX/hv4YsI8PSfw5AMfAvt1Dmuk+TdXsoUfuFrOTkhiJttyOSxip3X5jP6oK0Vd1GjZlIWU4B4Y8SbFQsI2OTqfWIdqgmEXhvzrQ5mRwSrsbfTC7AjpxG7lZV7qebGkPaYGYiBxP7Bm2cNd+yjtKGg6DFG4X6D49R4rXC2slq9WzYDgvLuhIo7zAnntzN9REMeq4Q4+ZU2qVV240Xgyb9QEQrye/AZfnmlOxgWWfuOy6wHW5TWazACw==;
+\t\tx-lets-make-this-really-long; t=1609459201;\r
+\tb=kNEseaF1ozpjc3/BnUgXqRjl99TIOmxnIlXzQEGu9B3HkUmiZM3sY9jkoqo3x44DlxZv2sEsd\r
+\todQQ8NivIvruQb7tkgRrnhB+54fVh7mfxiG3q1CB3fFkz13FPU85UkE/Y5HozEfjfSBiBDMnguv\r
+\tZyh/M4SVbDAXxBeQWHVVggkUQoyRy7X9vdlK3vRWQq+mdFINEUITKSI6GAUJdtWDTUad3/DnOm5\r
+\tykzWZkIcX7u+ng2jXC7wI+cko4+dLzdy9SIKaL1rEqdiF+IDRnR1yLDBZjQXUyzPkLYKzmrOAsb\r
+\tF1E9z34xwGjT0F3+TKbcupxg8mHnn0QBU8PXCKb+NYbQ==;
 "#
         );
     }
@@ -512,7 +524,8 @@ Joe."#
 DKIM-Signature: v=1; a=ed25519-sha256; d=football.example.com; s=brisbane;\r
 \tc=relaxed/relaxed; bh=2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8=;\r
 \th=from:to:subject:date:message-id:from:subject:date; t=1528637909;\r
-\tb=wITr2H3sBuBfMsnUwlRTO7Oq/C/jd2vubDm50DrXtMFEBLRiz9GfrgCozcg764+gYqWXV3Snd1ynYh8sJ5BXBg==;
+\tb=wITr2H3sBuBfMsnUwlRTO7Oq/C/jd2vubDm50DrXtMFEBLRiz9GfrgCozcg764+gYqWXV3Snd\r
+\t1ynYh8sJ5BXBg==;
 "#
         );
     }


### PR DESCRIPTION
### Motivation
During post-migration validation of a CIDR block of customer mail, AWS SES testing endpoint reported dkim=permerror on DKIM signatures generated by KumoMTA after migration. This indicated a signature formatting issue that could impact delivery for customers using strict DKIM validators. The issue only manifested when signing many headers (especially with List-Unsubscribe headers included), suggesting a formatting bug rather than a cryptographic problem. Interestingly, more lenient validators (like Outlook) accepted the same messages, confirming the issue was specific to header formatting rather than the signing algorithm.

### Problem Statement
The DKIM-Signature header generation in KumoMTA had a critical bug in RFC 5322 header folding logic. When the h= parameter (list of signed headers) exceeded the 75-character line length limit and needed to wrap across multiple lines, the folding algorithm would split header field names mid-word instead of only at proper delimiters (colons).

Example of Corrupted Output (observed in AWS SES testing):

```
h=from:to:subject:date:message-id:list-unsubscrib	e:		list-unsubscribe-post:...
                                              ^^^^^ SPLIT IN MIDDLE OF HEADER NAME
```
This malformed h= value would be inserted into the DKIM-Signature header, creating an unparseable signature that strict validators reject while lenient validators attempt to work around.

### Root Cause
The serialize() function in header.rs (lines 97-170) performed two sequential wrapping operations:

- First wrap (lines 119-151): Custom colon-aware wrapping for the h= parameter using a custom word separator that breaks only after colons (correct)
- Second wrap (lines 162-169): Generic textwrap::fill() with AsciiSpace word separator applied to the entire output (probably incorrect)

The second wrap would re-wrap already-wrapped content, and since it only understood space-delimited words, it could break header names mid-word when they didn't fit on a single 75-character line. The h= value would be unwrapped and re-wrapped without understanding its colon-delimited structure.

### Solution
Modified the serialize() function to intelligently handle wrapping:
- Detect pre-wrapped content: Check if output contains \r\n (indicating h= or b= already on separate lines)
- Selective wrapping: Only apply generic wrapping to content before the first line break
- Preserve special parameters: Keep the already-wrapped h=/b= sections intact with proper RFC 5322 tab indentation
- Safe fallback: For short output without line breaks, apply standard wrapping as before

This ensures that:
- The colon-aware h= wrapping is preserved exactly as formatted
- Header names are never split mid-word
- RFC 5322 compliance is maintained (proper tab indentation for continuation lines)
- Backward compatibility is preserved for all other use cases