### PR TITLE
Docs: Update use of dnf during installation

### DIFF
--- a/docs/tutorial/installing_kumomta.md
+++ b/docs/tutorial/installing_kumomta.md
@@ -9,7 +9,7 @@ sudo dnf -y install dnf-plugins-core
 sudo dnf config-manager \
     --add-repo \
     https://openrepo.kumomta.com/files/kumomta-rocky.repo
-sudo yum install kumomta
+sudo dnf install kumomta
 ```
 
 This installs the KumoMTA daemon to /opt/kumomta/sbin/kumod

--- a/docs/userguide/installation/linux.md
+++ b/docs/userguide/installation/linux.md
@@ -12,7 +12,7 @@ The install instructions for supported platforms are shown below. If your platfo
     $ sudo dnf -y install dnf-plugins-core
     $ sudo dnf config-manager --add-repo \
         https://openrepo.kumomta.com/files/kumomta-rocky.repo
-    $ sudo yum install kumomta
+    $ sudo dnf install kumomta
     ```
 
 === "Ubuntu 22.04 LTS"
@@ -68,7 +68,7 @@ If you want to test the latest additions and improvements to KumoMTA, you can in
     $ sudo dnf -y install dnf-plugins-core
     $ sudo dnf config-manager --add-repo \
         https://openrepo.kumomta.com/files/kumomta-rocky.repo
-    $ sudo yum install kumomta-dev
+    $ sudo dnf install kumomta-dev
     ```
 
 === "Ubuntu 22.04 LTS"
@@ -108,7 +108,7 @@ If you want to test the latest additions and improvements to KumoMTA, you can in
     $ sudo dnf -y install dnf-plugins-core
     $ sudo dnf config-manager --add-repo \
         https://openrepo.kumomta.com/files/kumomta-amazon2023.repo
-    $ sudo yum install kumomta-dev
+    $ sudo dnf install kumomta-dev
     ```
 
 ## The Initial Config File


### PR DESCRIPTION
On systems that have DNF as package manager, use it to install the package instead of yum. The result is the same, yum is a symlink to dnf on these systems.