### PR TITLE
Use correct option add_auth_results_header

### DIFF
--- a/docs/reference/policy-extras.mail_auth/check.md
+++ b/docs/reference/policy-extras.mail_auth/check.md
@@ -40,14 +40,14 @@ following fields; all fields are optional:
  * `arc` - a boolean, which defaults to `true`, indicating whether
    [msg:arc_verify](../message/arc_verify.md) should be called and the result
    collected.
- * `add_authentication_results` - a boolean, which defaults to `true`, indicating
+ * `add_auth_results_header` - a boolean, which defaults to `true`, indicating
    whether the aggregated authentication results performed by `check` should be
    added to the message as an
    [Authentication-Results](https://datatracker.ietf.org/doc/html/rfc8601#autoid-1)
    header via [msg:add_authentication_results](../message/add_authentication_results.md).
  * `server_id` - a string which specifies the `server_id` parameter that should be
    passed to [msg:add_authentication_results](../message/add_authentication_results.md)
-   when `add_authentication_results` is enabled.  If you do not specify `server_id`
+   when `add_auth_results_header` is enabled.  If you do not specify `server_id`
    then the `hostname` metadata value will be extracted from the `MSG`.
  * `resolver` - a string corresponding to the name of a resolver defined via
    [kumo.dns.define_resolver](../kumo.dns/define_resolver.md) for more advanced


### PR DESCRIPTION
Updating the wrongly stated "add_authentication_results" to the correct "add_auth_results_header" in check.md.

For code reference see: https://github.com/KumoCorp/kumomta/blob/1c5221ba006c7522c0f74f81fad9da18924ac753/assets/policy-extras/mail_auth.lua#L23