### PR TITLE
audit series using kumo-counter-series

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3914,6 +3914,7 @@ dependencies = [
  "metrics-tracing-context",
  "mlua",
  "mod-amqp",
+ "mod-audit-series",
  "mod-aws-sigv4",
  "mod-crypto",
  "mod-digest",
@@ -4845,6 +4846,19 @@ dependencies = [
  "tokio-executor-trait",
  "tokio-reactor-trait",
  "tracing",
+]
+
+[[package]]
+name = "mod-audit-series"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "config",
+ "dashmap",
+ "duration-serde",
+ "kumo-counter-series",
+ "mlua",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/kcli",
   "crates/kumo-address",
   "crates/kumo-api-client",
+  "crates/mod-audit-series",
   "crates/kumo-chrono-helper",
   "crates/kumo-counter-series",
   "crates/kumo-jsonl",

--- a/crates/kumo-server-common/Cargo.toml
+++ b/crates/kumo-server-common/Cargo.toml
@@ -24,6 +24,7 @@ duration-serde = {path="../duration-serde"}
 gethostname = {workspace=true}
 human_bytes = {workspace=true}
 kumo-api-types = {path="../kumo-api-types"}
+mod-audit-series = {path="../mod-audit-series"}
 kumo-machine-info = {path="../kumo-machine-info"}
 kumo-prometheus = {path="../kumo-prometheus"}
 kumo-server-lifecycle = {path="../kumo-server-lifecycle"}

--- a/crates/kumo-server-common/src/lib.rs
+++ b/crates/kumo-server-common/src/lib.rs
@@ -40,6 +40,7 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
         mod_crypto::register,
         mod_smtp_response_normalize::register,
         kumo_jsonl::lua::register,
+        mod_audit_series::register,
         mod_string::register,
         mod_time::register,
         mod_dns_resolver::register,

--- a/crates/mod-audit-series/Cargo.toml
+++ b/crates/mod-audit-series/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mod-audit-series"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+config = { path = "../config" }
+dashmap = { workspace = true }
+duration-serde = {path="../duration-serde"}
+kumo-counter-series = { path = "../kumo-counter-series" }
+mlua = { workspace = true, features = ["vendored", "lua54", "async", "send", "serialize"] }
+tokio = { workspace = true, features = ["time"] }

--- a/crates/mod-audit-series/src/lib.rs
+++ b/crates/mod-audit-series/src/lib.rs
@@ -1,0 +1,121 @@
+use config::get_or_create_sub_module;
+use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
+use kumo_counter_series::{CounterSeries, CounterSeriesConfig};
+use mlua::{Lua, LuaSerdeExt, UserData, UserDataMethods, Value};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+static CACHE: LazyLock<DashMap<String, Arc<Mutex<CounterSeries>>>> = LazyLock::new(DashMap::new);
+
+struct LuaAuditSeries {
+    series: Arc<Mutex<CounterSeries>>,
+}
+
+impl LuaAuditSeries {
+    fn with_series<T>(
+        &self,
+        f: impl FnOnce(&mut CounterSeries) -> mlua::Result<T>,
+    ) -> mlua::Result<T> {
+        let mut guard = self
+            .series
+            .lock()
+            .map_err(|_| mlua::Error::external("failed to acquire lock"))?;
+        f(&mut guard)
+    }
+
+    fn increment(&self, to_add: u64) -> mlua::Result<()> {
+        self.with_series(|series| {
+            series.increment(to_add);
+            Ok(())
+        })
+    }
+
+    fn delta(&self, delta: i64) -> mlua::Result<()> {
+        self.with_series(|series| {
+            series.delta(delta);
+            Ok(())
+        })
+    }
+
+    fn observe(&self, value: u64) -> mlua::Result<()> {
+        self.with_series(|series| {
+            series.observe(value);
+            Ok(())
+        })
+    }
+
+    fn sum(&self) -> mlua::Result<u64> {
+        self.with_series(|series| Ok(series.sum()))
+    }
+
+    fn sum_over(&self, lua: &Lua, duration: Value) -> mlua::Result<u64> {
+        let duration: duration_serde::Wrap<Duration> = lua.from_value(duration)?;
+        let duration = duration.into_inner();
+        self.with_series(|series| Ok(series.sum_over(duration)))
+    }
+}
+
+impl UserData for LuaAuditSeries {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("increment", |_lua, this, inc| this.increment(inc));
+        methods.add_method("delta", |_lua, this, delta| this.delta(delta));
+        methods.add_method("observe", |_lua, this, value| this.observe(value));
+        methods.add_method("sum", |_lua, this, ()| this.sum());
+        methods.add_method("sum_over", |lua, this, duration: Value| {
+            this.sum_over(lua, duration)
+        });
+    }
+}
+
+fn make_config(num_buckets: u8, bucket_size_seconds: u64) -> mlua::Result<CounterSeriesConfig> {
+    if num_buckets == 0 {
+        return Err(mlua::Error::external("num_buckets must be >= 1"));
+    }
+    if bucket_size_seconds == 0 {
+        return Err(mlua::Error::external("bucket_size_seconds must be >= 1"));
+    }
+
+    Ok(CounterSeriesConfig {
+        num_buckets,
+        bucket_size: bucket_size_seconds,
+    })
+}
+
+pub fn register(lua: &Lua) -> anyhow::Result<()> {
+    let audit_mod = get_or_create_sub_module(lua, "audit_series")?;
+
+    audit_mod.set(
+        "define",
+        lua.create_function(
+            |lua,
+             (name, num_buckets, bucket_size, initial_value): (
+                String,
+                u8,
+                Value,
+                Option<u64>,
+            )| {
+                let shared = match CACHE.entry(name) {
+                    Entry::Occupied(entry) => Arc::clone(entry.get()),
+                    Entry::Vacant(entry) => {
+                        let bucket_size: duration_serde::Wrap<Duration> =
+                            lua.from_value(bucket_size)?;
+                        let bucket_size_seconds = bucket_size.into_inner().as_secs();
+                        let config = make_config(num_buckets, bucket_size_seconds)?;
+                        let series = match initial_value {
+                            Some(value) => CounterSeries::with_initial_value(config, value),
+                            None => CounterSeries::with_config(config),
+                        };
+                        let shared = Arc::new(Mutex::new(series));
+                        entry.insert(Arc::clone(&shared));
+                        shared
+                    }
+                };
+
+                Ok(LuaAuditSeries { series: shared })
+            },
+        )?,
+    )?;
+
+    Ok(())
+}

--- a/crates/mod-audit-series/test.lua
+++ b/crates/mod-audit-series/test.lua
@@ -1,0 +1,25 @@
+local kumo = require 'kumo'
+
+-- Confirm that initial value is set correctly
+local initial = kumo.audit_series.define('test.initial', 6, '60s', 10)
+
+assert(initial:sum() == 10, 'sum after initial value should be 10')
+
+-- define(name, num_buckets, bucket_size_seconds, initial_value)
+local audit = kumo.audit_series.define('test.audit', 6, '1m')
+
+-- Calling define with the same name should return the existing cached series.
+local same = kumo.audit_series.define('test.audit', 6, '60s')
+
+audit:increment(2)
+audit:delta(-1)
+assert(audit:sum() == 1, 'sum after increment+delta should be 1')
+assert(same:sum() == 1, 'second handle should see same cached value')
+
+audit:observe(10)
+
+assert(audit:sum() == 10, 'sum after observe should be 10')
+assert(
+  audit:sum_over '2m' == 10,
+  'sum_over should include current bucket value'
+)

--- a/docs/reference/kumo.audit_series/_index.md
+++ b/docs/reference/kumo.audit_series/_index.md
@@ -1,0 +1,14 @@
+---
+tags:
+ - audit_series
+---
+
+# Module `kumo.audit_series`
+
+{{since('dev')}}
+
+# Audit_series
+
+Audit_series maintains an in-memory chronological set of metrics of events. Metrics are not persisted across process restarts, nor shared between nodes, and are only meant for short-term bookkeeping of events in the current process instance. If persistence or data sharing across multiple kumomta instances is important, try using external database such as redis for storage.
+
+## Available Methods { data-search-exclude }

--- a/docs/reference/kumo.audit_series/define.md
+++ b/docs/reference/kumo.audit_series/define.md
@@ -1,0 +1,27 @@
+---
+tags:
+  - audit_series
+---
+
+# audit_series.define
+
+```lua
+kumo.audit_series.define(name, window_count, window_duration, initial_value)
+```
+
+{{since('dev')}}
+
+Creates and returns a named rolling counter series.
+
+* `name`: unique series name. Calling `define` again with the same name returns the existing series; other arguments are ignored.
+* `window_count`: window count to maintain.
+* `window_duration` : duration of each window. Accepts seconds or a duration string like `"5s"`.
+* `initial_value` : optional value to initialize the series. Omit to initialize as zero.
+
+Total retention span is `window_count * window_duration`.
+Values are stored as `u64`.
+
+```lua
+local audit = kumo.audit_series.define('test.audit', 5, '1m')
+audit:increment(1)
+```

--- a/docs/reference/kumo.audit_series/delta.md
+++ b/docs/reference/kumo.audit_series/delta.md
@@ -1,0 +1,26 @@
+---
+tags:
+  - audit_series
+---
+
+# audit_series.delta
+
+```lua
+audit:delta(value)
+```
+
+{{since('dev')}}
+
+Adjusts the current window by a signed amount.
+
+* `value`: signed integer delta.
+
+Positive values increase; negative values decrease.
+The value saturates at `0` and never goes negative.
+
+Error is generated if audit series name is not yet defined.
+
+```lua
+audit:delta(2)
+audit:delta(-1)
+```

--- a/docs/reference/kumo.audit_series/increment.md
+++ b/docs/reference/kumo.audit_series/increment.md
@@ -1,0 +1,24 @@
+---
+tags:
+  - audit_series
+---
+
+# audit_series.increment
+
+```lua
+audit:increment(value)
+```
+
+{{since('dev')}}
+
+Adds `value` to the current window.
+
+* `value`: unsigned integer amount to add.
+
+To subtract, use [audit_series.delta](delta.md) with a negative value.
+
+Error is generated if audit series name is not yet defined.
+
+```lua
+audit:increment(1)
+```

--- a/docs/reference/kumo.audit_series/sum.md
+++ b/docs/reference/kumo.audit_series/sum.md
@@ -1,0 +1,23 @@
+---
+tags:
+  - audit_series
+---
+
+# audit_series.sum
+
+```lua
+audit:sum()
+```
+
+{{since('dev')}}
+
+Returns the rolling total across all configured windows.
+
+Use this when you want the full series total.
+Use [audit_series.sum_over](sum_over.md) to sum a shorter span.
+
+Error is generated if audit series name is not yet defined.
+
+```lua
+print('Total Value: ', audit:sum())
+```

--- a/docs/reference/kumo.audit_series/sum_over.md
+++ b/docs/reference/kumo.audit_series/sum_over.md
@@ -1,0 +1,25 @@
+---
+tags:
+  - audit_series
+---
+
+# audit_series.sum_over
+
+```lua
+audit:sum_over(duration)
+```
+
+{{since('dev')}}
+
+Returns the rolling total over the requested time span.
+
+* `duration`: the span to sum over.
+
+The duration is rounded up to full buckets and capped by the configured window count.
+
+Error is generated if audit series name is not yet defined.
+
+```lua
+local audit = kumo.audit_series.define('test.audit', 5, '1m')
+print('last 5m:', audit:sum_over('5m'))
+```


### PR DESCRIPTION
Continuation of https://github.com/KumoCorp/kumomta/pull/470

kumo.audit_series uses kumo-counter-series internally to maintain an in memory sliding window counters.
The main objective of this module is to be able to track counts of specific events.

For example count the number of failures against redis. Repeated failure can negatively impact the performance of the MTA. In such case, I would like the code to bypass making calls to redis.

The counters are tracked in memory thus restarting the service would reset the values. 