### PR TITLE
make_message fails for from address which starts with postmaster

### DIFF
--- a/crates/rfc5321/src/client.rs
+++ b/crates/rfc5321/src/client.rs
@@ -1187,7 +1187,7 @@ fn apply_dot_stuffing(data: &[u8]) -> Option<Vec<u8>> {
 /// eg:
 /// ```no_run
 /// ["C=US", "ST=CA", "L=SanFrancisco", "O=Fort-Funston", "OU=MyOrganizationalUnit",
-/// "CN=do.havedane.net", "name=EasyRSA", "emailAddress=me@myhost.mydomain"]
+/// "CN=do.havedane.net", "name=EasyRSA", "emailAddress=me@myhost.mydomain"];
 /// ```
 pub fn subject_name(cert: &X509Ref) -> Vec<String> {
     let mut subject_name = vec![];

--- a/crates/rfc5321/src/parser.rs
+++ b/crates/rfc5321/src/parser.rs
@@ -468,9 +468,9 @@ impl EnvelopeAddress {
         let (_, result) = all_consuming(alt((
             map(tag_no_case("<>"), |_| EnvelopeAddress::Null),
             map(tag_no_case("<Postmaster>"), |_| EnvelopeAddress::Postmaster),
-            map(tag_no_case("Postmaster"), |_| EnvelopeAddress::Postmaster),
             map(path, EnvelopeAddress::Path),
             map(mailbox, EnvelopeAddress::from),
+            map(tag_no_case("Postmaster"), |_| EnvelopeAddress::Postmaster),
         )))
         .parse(input)
         .map_err(|e| explain_nom(input, e))?;
@@ -3723,6 +3723,12 @@ Ok(
         let addr = EnvelopeAddress::Postmaster;
         let debug_str = format!("{:?}", addr);
         k9::assert_equal!(debug_str, "<Postmaster>");
+    }
+
+    #[test]
+    fn test_envelope_address_postmaster_full_address() {
+        let postmaster = EnvelopeAddress::parse(r#"postmaster@example.com"#).unwrap();
+        k9::assert_equal!(postmaster.to_string(), r#"postmaster@example.com"#);
     }
 
     #[test]


### PR DESCRIPTION
When running make_message with from address which is prefixed with postmaster, the EnvelopeAddress::parse function is failing.

```
Error: Shutdown due to error: Error at line 1, in Eof:
postmaster@domain.com
          ^____________________


stack traceback:
        [C]: in function 'kumo.make_message'
        [string "/tmp/test.lua"]:154: in upvalue 'scan'
        [string "/tmp/test.lua"]:201: in function <[string "/tmp/test.lua"]:188>
```

Not directly related to the fix, but crates/rfc5321/src/client.rs is failing to run the test with error below.
This is also addressed

```
running 1 test
error[E0308]: mismatched types
 --> crates/rfc5321/src/client.rs:1189:1
  |
2 |   fn main() { #[allow(non_snake_case)] fn _doctest_main_crates_rfc5321_src_client_rs_1188_0() {
  |                                                                                              - help: try adding a return type: `-> [&str; 8]`
3 | / ["C=US", "ST=CA", "L=SanFrancisco", "O=Fort-Funston", "OU=MyOrganizationalUnit",
4 | | "CN=do.havedane.net", "name=EasyRSA", "emailAddress=me@myhost.mydomain"]
  | |________________________________________________________________________^ expected `()`, found `[&str; 8]`

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0308`.
Couldn't compile the test.test crates/rfc5321/src/client.rs - client::subject_name (line 1188) - compile ... FAILED
```