### PR TITLE
Fix multiple issue relating to DMARC evaluation

### DIFF
--- a/crates/dkim/src/lib.rs
+++ b/crates/dkim/src/lib.rs
@@ -258,6 +258,33 @@ pub async fn verify_email_with_resolver<'a>(
     email: &'a ParsedEmail<'a>,
     resolver: &dyn Resolver,
 ) -> Result<Vec<AuthenticationResult>, DKIMError> {
+    fn populate_props(tagged_header: &TaggedHeader) -> BTreeMap<String, bstr::BString> {
+        let mut props = BTreeMap::new();
+
+        if let Some(signing_domain) = tagged_header.get_tag("d") {
+            props.insert("header.d".into(), signing_domain.into());
+            props.insert("header.i".into(), format!("@{signing_domain}").into());
+        }
+        if let Some(a_tag) = tagged_header.get_tag("a") {
+            props.insert("header.a".into(), a_tag.into());
+        }
+        if let Some(s_tag) = tagged_header.get_tag("s") {
+            props.insert("header.s".into(), s_tag.into());
+        }
+
+        if let Some(c_tag) = tagged_header.get_tag("c") {
+            props.insert("header.c".into(), c_tag.into());
+        }
+        if let Some(t_tag) = tagged_header.get_tag("t") {
+            props.insert("header.t".into(), t_tag.into());
+        }
+        if let Some(x_tag) = tagged_header.get_tag("x") {
+            props.insert("header.x".into(), x_tag.into());
+        }
+
+        props
+    }
+
     let mut results = vec![];
 
     let mut dkim_headers = vec![];
@@ -269,21 +296,21 @@ pub async fn verify_email_with_resolver<'a>(
             break;
         }
 
-        match h
-            .get_raw_value_string()
-            .map_err(Into::into)
-            .and_then(DKIMHeader::parse)
-        {
+        let raw_header = h.get_raw_value_string()?;
+        match DKIMHeader::parse(&raw_header) {
             Ok(v) => {
                 dkim_headers.push(v);
             }
             Err(err) => {
+                let props = TaggedHeader::parse(&raw_header)
+                    .map(|tagged| populate_props(&tagged))
+                    .unwrap_or_default();
                 results.push(AuthenticationResult {
                     method: "dkim".into(),
                     method_version: None,
                     result: "permerror".into(),
                     reason: Some(format!("{err}").into()),
-                    props: BTreeMap::new(),
+                    props,
                 });
             }
         }
@@ -315,13 +342,7 @@ pub async fn verify_email_with_resolver<'a>(
     }
 
     for dkim_header in &dkim_headers {
-        let signing_domain = dkim_header.get_required_tag("d");
-        let mut props = BTreeMap::new();
-
-        props.insert("header.d".into(), signing_domain.into());
-        props.insert("header.i".into(), format!("@{signing_domain}").into());
-        props.insert("header.a".into(), dkim_header.get_required_tag("a").into());
-        props.insert("header.s".into(), dkim_header.get_required_tag("s").into());
+        let mut props = populate_props(dkim_header);
 
         let b_tag = compute_header_b(dkim_header.get_required_tag("b"), &dkim_headers);
         props.insert("header.b".into(), b_tag.into());
@@ -367,6 +388,7 @@ pub async fn verify_email<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bstr::ByteSlice;
     use dns_resolver::TestResolver;
 
     const NEW_ENGLAND_DKIM: (&str, &str) = (
@@ -456,6 +478,47 @@ b=dzdVyOfAKCdLXdJOc9G2q8LoXSlEniSbav+yuU4zGeeruD00lszZ
             DKIMHeader::parse(&header).unwrap_err(),
             DKIMError::SignatureExpired
         );
+    }
+
+    #[tokio::test]
+    async fn test_expired_signature_populates_props() {
+        let x_value = "1";
+
+        let raw_email = format!(
+            "DKIM-Signature: v=1; a=rsa-sha256; c=simple/simple; d=example.net; s=brisbane; h=From; bh=hash; b=abcdefgh12345678; t=1; x={}\r\nFrom: user@example.net\r\n\r\nhello",
+            x_value,
+        );
+
+        let email = ParsedEmail::parse(raw_email).unwrap();
+        let resolver = TestResolver::default();
+
+        let res = verify_email_with_resolver(&email, &resolver).await.unwrap();
+        assert_eq!(res.len(), 1);
+
+        let result = &res[0];
+        assert_eq!(result.result, "permerror");
+        assert_eq!(
+            result.props.get("header.d").unwrap().to_str().unwrap(),
+            "example.net"
+        );
+        assert_eq!(
+            result.props.get("header.a").unwrap().to_str().unwrap(),
+            "rsa-sha256"
+        );
+        assert_eq!(
+            result.props.get("header.s").unwrap().to_str().unwrap(),
+            "brisbane"
+        );
+        assert_eq!(
+            result.props.get("header.c").unwrap().to_str().unwrap(),
+            "simple/simple"
+        );
+        assert_eq!(result.props.get("header.t").unwrap().to_str().unwrap(), "1");
+        assert_eq!(
+            result.props.get("header.x").unwrap().to_str().unwrap(),
+            x_value
+        );
+        assert!(result.props.get("header.b").is_none());
     }
 
     #[tokio::test]

--- a/crates/dkim/src/roundtrip_test.rs
+++ b/crates/dkim/src/roundtrip_test.rs
@@ -96,9 +96,11 @@ Hello Alice
         props: {
             "header.a": "rsa-sha256",
             "header.b": "vHLsP0n+",
+            "header.c": "simple/simple",
             "header.d": "cloudflare.com",
             "header.i": "@cloudflare.com",
             "header.s": "2022",
+            "header.t": "1609459201",
         },
     },
     AuthenticationResult {
@@ -109,9 +111,11 @@ Hello Alice
         props: {
             "header.a": "rsa-sha256",
             "header.b": "fdUa++8n",
+            "header.c": "simple/simple",
             "header.d": "not.cloudflare.com",
             "header.i": "@not.cloudflare.com",
             "header.s": "2022",
+            "header.t": "1609459201",
         },
     },
     AuthenticationResult {
@@ -124,9 +128,11 @@ Hello Alice
         props: {
             "header.a": "rsa-sha256",
             "header.b": "U0HRrJ9u",
+            "header.c": "simple/simple",
             "header.d": "cloudflare.com",
             "header.i": "@cloudflare.com",
             "header.s": "bogus-selector",
+            "header.t": "1609459201",
         },
     },
 ]
@@ -158,9 +164,11 @@ From: Sven Sauleau <sven@cloudflare.com>
         props: {
             "header.a": "rsa-sha256",
             "header.b": "qSowczhl",
+            "header.c": "simple/simple",
             "header.d": "cloudflare.com",
             "header.i": "@cloudflare.com",
             "header.s": "2022",
+            "header.t": "1609459201",
         },
     },
     AuthenticationResult {
@@ -171,9 +179,11 @@ From: Sven Sauleau <sven@cloudflare.com>
         props: {
             "header.a": "rsa-sha256",
             "header.b": "UZw1wwBY",
+            "header.c": "simple/simple",
             "header.d": "not.cloudflare.com",
             "header.i": "@not.cloudflare.com",
             "header.s": "2022",
+            "header.t": "1609459201",
         },
     },
     AuthenticationResult {
@@ -186,9 +196,11 @@ From: Sven Sauleau <sven@cloudflare.com>
         props: {
             "header.a": "rsa-sha256",
             "header.b": "GI3Q15Rv",
+            "header.c": "simple/simple",
             "header.d": "cloudflare.com",
             "header.i": "@cloudflare.com",
             "header.s": "bogus-selector",
+            "header.t": "1609459201",
         },
     },
 ]
@@ -259,9 +271,11 @@ sentation" style=3D"width:100%;">
         props: {
             "header.a": "rsa-sha256",
             "header.b": "h60+VEgs",
+            "header.c": "simple/simple",
             "header.d": "cloudflare.com",
             "header.i": "@cloudflare.com",
             "header.s": "2022",
+            "header.t": "1609459201",
         },
     },
     AuthenticationResult {
@@ -272,9 +286,11 @@ sentation" style=3D"width:100%;">
         props: {
             "header.a": "rsa-sha256",
             "header.b": "WzP4DTuC",
+            "header.c": "simple/simple",
             "header.d": "not.cloudflare.com",
             "header.i": "@not.cloudflare.com",
             "header.s": "2022",
+            "header.t": "1609459201",
         },
     },
     AuthenticationResult {
@@ -287,9 +303,11 @@ sentation" style=3D"width:100%;">
         props: {
             "header.a": "rsa-sha256",
             "header.b": "WKnfSsMb",
+            "header.c": "simple/simple",
             "header.d": "cloudflare.com",
             "header.i": "@cloudflare.com",
             "header.s": "bogus-selector",
+            "header.t": "1609459201",
         },
     },
 ]

--- a/crates/kumo-dmarc/src/lib.rs
+++ b/crates/kumo-dmarc/src/lib.rs
@@ -11,6 +11,7 @@ use crate::types::report_failure::ReportFailure;
 use crate::types::report_metadata::ReportMetadata;
 use crate::types::results::{AuthResults, DmarcResult, PolicyEvaluated, Results, Row};
 pub use crate::types::results::{Disposition, DispositionWithContext};
+use bstr::BString;
 use chrono::{DateTime, Utc};
 use dns_resolver::Resolver;
 use mailparsing::AuthenticationResult;
@@ -404,9 +405,11 @@ impl<'a> DmarcContext<'a> {
         match fetch_dmarc_records(&dmarc_domain, resolver).await {
             DmarcRecordResolution::Records(records) => {
                 for record in records {
-                    return record
+                    let mut result = record
                         .evaluate(self, &dmarc_domain, SenderDomainAlignment::Exact)
                         .await;
+                    result.props.extend(policy_tags(&record));
+                    return result;
                 }
             }
             x => {
@@ -421,23 +424,27 @@ impl<'a> DmarcContext<'a> {
                                         "DNS records could not be resolved for {}",
                                         address
                                     ),
+                                    props: BTreeMap::new(),
                                 }
                             }
                             DmarcRecordResolution::PermError => {
                                 return DispositionWithContext {
                                     result: Disposition::PermError,
                                     context: format!("no DMARC records found for {}", address),
+                                    props: BTreeMap::new(),
                                 }
                             }
                             DmarcRecordResolution::Records(records) => {
                                 for record in records {
-                                    return record
+                                    let mut result = record
                                         .evaluate(
                                             self,
                                             &address,
                                             SenderDomainAlignment::OrganizationalDomain,
                                         )
                                         .await;
+                                    result.props.extend(policy_tags(&record));
+                                    return result;
                                 }
                             }
                         }
@@ -445,6 +452,7 @@ impl<'a> DmarcContext<'a> {
                         return DispositionWithContext {
                             result: x.into(),
                             context: format!("no DMARC records found for {}", &self.from_domain),
+                            props: BTreeMap::new(),
                         };
                     }
                 }
@@ -454,8 +462,19 @@ impl<'a> DmarcContext<'a> {
         DispositionWithContext {
             result: Disposition::None,
             context: format!("no DMARC records found for {}", &self.from_domain),
+            props: BTreeMap::new(),
         }
     }
+}
+
+fn policy_tags(record: &Record) -> BTreeMap<String, BString> {
+    let mut props = BTreeMap::new();
+
+    for (tag, value) in record.tags() {
+        props.insert(format!("policy.{tag}").into(), value.as_str().into());
+    }
+
+    props
 }
 
 // The output is wrapped in a Result to allow matching on errors.

--- a/crates/kumo-dmarc/src/tests.rs
+++ b/crates/kumo-dmarc/src/tests.rs
@@ -31,7 +31,7 @@ async fn dmarc_dkim_relaxed_subdomain() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Pass);
+    k9::snapshot!(result.result, "Pass");
 }
 
 #[tokio::test]
@@ -54,7 +54,7 @@ async fn dmarc_dkim_relaxed_subdomain_deep() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Pass);
+    k9::snapshot!(result.result, "Pass");
 }
 
 #[tokio::test]
@@ -77,7 +77,7 @@ async fn dmarc_dkim_relaxed_subdomain_fail() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Reject);
+    k9::snapshot!(result.result, "Reject");
 }
 
 #[tokio::test]
@@ -100,7 +100,7 @@ async fn dmarc_dkim_relaxed_subdomain_sp_quarantine_fail() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Quarantine);
+    k9::snapshot!(result.result, "Quarantine");
 }
 
 #[tokio::test]
@@ -123,7 +123,7 @@ async fn dmarc_dkim_strict_subdomain() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Pass);
+    k9::snapshot!(result.result, "Pass");
 }
 
 #[tokio::test]
@@ -146,7 +146,129 @@ async fn dmarc_dkim_strict_subdomain_fail() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Reject);
+    k9::snapshot!(result.result, "Reject");
+}
+
+#[tokio::test]
+async fn dmarc_dkim_ignores_non_pass_results() {
+    let resolver = TestResolver::default()
+        .with_zone(EXAMPLE_COM)
+        .unwrap()
+        .with_txt(
+            "_dmarc.example.com",
+            "v=DMARC1; p=reject; adkim=s; \
+            rua=mailto:dmarc-feedback@example.com"
+                .to_string(),
+        );
+
+    let mut dkim_fail = AuthenticationResult {
+        method: "dkim".into(),
+        method_version: None,
+        result: Default::default(),
+        reason: None,
+        props: BTreeMap::new(),
+    };
+    dkim_fail.props.insert("result".into(), "fail".into());
+    dkim_fail
+        .props
+        .insert("header.d".into(), "example.org".into());
+
+    let mut dkim_pass = AuthenticationResult {
+        method: "dkim".into(),
+        method_version: None,
+        result: Default::default(),
+        reason: None,
+        props: BTreeMap::new(),
+    };
+    dkim_pass.props.insert("result".into(), "pass".into());
+    dkim_pass
+        .props
+        .insert("header.d".into(), "example.com".into());
+
+    let mut spf_result = AuthenticationResult {
+        method: "spf".into(),
+        method_version: None,
+        result: Default::default(),
+        reason: None,
+        props: BTreeMap::new(),
+    };
+    spf_result.props.insert("result".into(), "pass".into());
+
+    let dkim_results = vec![dkim_fail, dkim_pass];
+    let mut dmarc_context = DmarcContext::new(
+        "example.com",
+        Some("example.com"),
+        &[],
+        "",
+        &dkim_results,
+        &spf_result,
+        None,
+    );
+
+    let result = dmarc_context.check(&resolver).await;
+
+    k9::snapshot!(result.result, "Pass");
+}
+
+#[tokio::test]
+async fn dmarc_dkim_continues_until_aligned_result() {
+    let resolver = TestResolver::default()
+        .with_zone(EXAMPLE_COM)
+        .unwrap()
+        .with_txt(
+            "_dmarc.example.com",
+            "v=DMARC1; p=reject; adkim=s; \
+            rua=mailto:dmarc-feedback@example.com"
+                .to_string(),
+        );
+
+    let mut dkim_unaligned = AuthenticationResult {
+        method: "dkim".into(),
+        method_version: None,
+        result: Default::default(),
+        reason: None,
+        props: BTreeMap::new(),
+    };
+    dkim_unaligned.props.insert("result".into(), "pass".into());
+    dkim_unaligned
+        .props
+        .insert("header.d".into(), "example.org".into());
+
+    let mut dkim_aligned = AuthenticationResult {
+        method: "dkim".into(),
+        method_version: None,
+        result: Default::default(),
+        reason: None,
+        props: BTreeMap::new(),
+    };
+    dkim_aligned.props.insert("result".into(), "pass".into());
+    dkim_aligned
+        .props
+        .insert("header.d".into(), "example.com".into());
+
+    let mut spf_result = AuthenticationResult {
+        method: "spf".into(),
+        method_version: None,
+        result: Default::default(),
+        reason: None,
+        props: BTreeMap::new(),
+    };
+    spf_result.props.insert("result".into(), "fail".into());
+
+    let dkim_results = vec![dkim_unaligned, dkim_aligned];
+    let mut dmarc_context = DmarcContext::new(
+        "example.com",
+        Some("example.com"),
+        &[],
+        "",
+        &dkim_results,
+        &spf_result,
+        None,
+    );
+
+    let result = dmarc_context.check(&resolver).await;
+
+    k9::snapshot!(result.result, "Pass");
 }
 
 #[tokio::test]
@@ -169,8 +291,8 @@ async fn dmarc_dkim_relaxed_illformed() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Reject);
-    k9::assert_equal!(result.context.contains("d="), true);
+    k9::snapshot!(result.result, "Reject");
+    k9::snapshot!(result.context, "DMARC: DKIM signature missing 'd=' tag");
 }
 
 #[tokio::test]
@@ -193,8 +315,8 @@ async fn dmarc_dkim_strict_illformed() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Reject);
-    k9::assert_equal!(result.context.contains("d="), true);
+    k9::snapshot!(result.result, "Reject");
+    k9::snapshot!(result.context, "DMARC: DKIM signature missing 'd=' tag");
 }
 
 #[tokio::test]
@@ -217,7 +339,7 @@ async fn dmarc_spf_relaxed_subdomain() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Pass);
+    k9::snapshot!(result.result, "Pass");
 }
 
 #[tokio::test]
@@ -240,7 +362,7 @@ async fn dmarc_spf_relaxed_subdomain_deep() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Pass);
+    k9::snapshot!(result.result, "Pass");
 }
 
 #[tokio::test]
@@ -263,7 +385,7 @@ async fn dmarc_spf_relaxed_subdomain_fail() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Reject);
+    k9::snapshot!(result.result, "Reject");
 }
 
 #[tokio::test]
@@ -286,7 +408,59 @@ async fn dmarc_spf_strict_subdomain() {
     })
     .await;
 
-    k9::assert_equal!(result.result, Disposition::Reject);
+    k9::snapshot!(result.result, "Reject");
+}
+
+#[tokio::test]
+async fn dmarc_spf_ignores_non_pass_result() {
+    let resolver = TestResolver::default()
+        .with_zone(EXAMPLE_COM)
+        .unwrap()
+        .with_txt(
+            "_dmarc.example.com",
+            "v=DMARC1; p=reject; aspf=s; adkim=s; \
+            rua=mailto:dmarc-feedback@example.com"
+                .to_string(),
+        );
+
+    let mut dkim_pass = AuthenticationResult {
+        method: "dkim".into(),
+        method_version: None,
+        result: Default::default(),
+        reason: None,
+        props: BTreeMap::new(),
+    };
+    dkim_pass.props.insert("result".into(), "pass".into());
+    dkim_pass
+        .props
+        .insert("header.d".into(), "example.com".into());
+
+    let mut spf_result = AuthenticationResult {
+        method: "spf".into(),
+        method_version: None,
+        result: Default::default(),
+        reason: None,
+        props: BTreeMap::new(),
+    };
+    spf_result.props.insert("result".into(), "fail".into());
+    spf_result
+        .props
+        .insert("smtp.mailfrom".into(), "helper.example.org".into());
+
+    let dkim_results = vec![dkim_pass];
+    let mut dmarc_context = DmarcContext::new(
+        "example.com",
+        Some("helper.example.org"),
+        &[],
+        "",
+        &dkim_results,
+        &spf_result,
+        None,
+    );
+
+    let result = dmarc_context.check(&resolver).await;
+
+    k9::snapshot!(result.result, "Pass");
 }
 
 #[tokio::test]
@@ -338,13 +512,19 @@ async fn evaluate_ip<'a>(
 ) -> DispositionWithContext {
     let mut dkim_vec = vec![];
 
-    let spf_result = AuthenticationResult {
+    let mut spf_result = AuthenticationResult {
         method: "spf".into(),
         method_version: None,
         result: Default::default(),
         reason: None,
         props: BTreeMap::new(),
     };
+    if dkim_domains.is_empty() {
+        spf_result.props.insert("result".into(), "pass".into());
+        spf_result
+            .props
+            .insert("smtp.mailfrom".into(), mail_from_domain.into());
+    }
 
     for dkim_domain in dkim_domains {
         let mut authentication_result = AuthenticationResult {
@@ -354,6 +534,10 @@ async fn evaluate_ip<'a>(
             reason: None,
             props: BTreeMap::new(),
         };
+
+        authentication_result
+            .props
+            .insert("result".into(), "pass".into());
 
         if let Some(dkim_domain) = dkim_domain {
             authentication_result

--- a/crates/kumo-dmarc/src/tests.rs
+++ b/crates/kumo-dmarc/src/tests.rs
@@ -12,6 +12,29 @@ struct TestData<'a> {
 }
 
 #[tokio::test]
+async fn dmarc_both_spf_and_dkim_fail_returns_fail() {
+    let resolver = TestResolver::default()
+        .with_zone(EXAMPLE_COM)
+        .unwrap()
+        .with_txt(
+            "_dmarc.example.com",
+            "v=DMARC1; p=reject; aspf=r; adkim=r; rua=mailto:dmarc-feedback@example.com"
+                .to_string(),
+        );
+
+    let result = evaluate_ip(TestData {
+        from_domain: "example.com",
+        mail_from_domain: "otherdomain.com",
+        dkim_domains: &[Some("otherdomain.com")],
+        resolver: &resolver,
+    })
+    .await;
+
+    k9::snapshot!(result.result, "Reject");
+    k9::snapshot!(result.context, "DMARC: DKIM relaxed check failed");
+}
+
+#[tokio::test]
 async fn dmarc_dkim_relaxed_subdomain() {
     let resolver = TestResolver::default()
         .with_zone(EXAMPLE_COM)
@@ -27,6 +50,29 @@ async fn dmarc_dkim_relaxed_subdomain() {
         from_domain: "sample.example.com",
         mail_from_domain: "sample.example.com",
         dkim_domains: &[Some("example.com")],
+        resolver: &resolver,
+    })
+    .await;
+
+    k9::snapshot!(result.result, "Pass");
+}
+
+#[tokio::test]
+async fn dmarc_dkim_relaxed_subdomain_reverse() {
+    let resolver = TestResolver::default()
+        .with_zone(EXAMPLE_COM)
+        .unwrap()
+        .with_txt(
+            "_dmarc.example.com",
+            "v=DMARC1; p=reject; adkim=r; \
+            rua=mailto:dmarc-feedback@example.com"
+                .to_string(),
+        );
+
+    let result = evaluate_ip(TestData {
+        from_domain: "example.com",
+        mail_from_domain: "example.com",
+        dkim_domains: &[Some("sample.example.com")],
         resolver: &resolver,
     })
     .await;
@@ -164,11 +210,10 @@ async fn dmarc_dkim_ignores_non_pass_results() {
     let mut dkim_fail = AuthenticationResult {
         method: "dkim".into(),
         method_version: None,
-        result: Default::default(),
+        result: "fail".into(),
         reason: None,
         props: BTreeMap::new(),
     };
-    dkim_fail.props.insert("result".into(), "fail".into());
     dkim_fail
         .props
         .insert("header.d".into(), "example.org".into());
@@ -176,23 +221,21 @@ async fn dmarc_dkim_ignores_non_pass_results() {
     let mut dkim_pass = AuthenticationResult {
         method: "dkim".into(),
         method_version: None,
-        result: Default::default(),
+        result: "pass".into(),
         reason: None,
         props: BTreeMap::new(),
     };
-    dkim_pass.props.insert("result".into(), "pass".into());
     dkim_pass
         .props
         .insert("header.d".into(), "example.com".into());
 
-    let mut spf_result = AuthenticationResult {
+    let spf_result = AuthenticationResult {
         method: "spf".into(),
         method_version: None,
-        result: Default::default(),
+        result: "pass".into(),
         reason: None,
         props: BTreeMap::new(),
     };
-    spf_result.props.insert("result".into(), "pass".into());
 
     let dkim_results = vec![dkim_fail, dkim_pass];
     let mut dmarc_context = DmarcContext::new(
@@ -225,11 +268,10 @@ async fn dmarc_dkim_continues_until_aligned_result() {
     let mut dkim_unaligned = AuthenticationResult {
         method: "dkim".into(),
         method_version: None,
-        result: Default::default(),
+        result: "pass".into(),
         reason: None,
         props: BTreeMap::new(),
     };
-    dkim_unaligned.props.insert("result".into(), "pass".into());
     dkim_unaligned
         .props
         .insert("header.d".into(), "example.org".into());
@@ -237,23 +279,21 @@ async fn dmarc_dkim_continues_until_aligned_result() {
     let mut dkim_aligned = AuthenticationResult {
         method: "dkim".into(),
         method_version: None,
-        result: Default::default(),
+        result: "pass".into(),
         reason: None,
         props: BTreeMap::new(),
     };
-    dkim_aligned.props.insert("result".into(), "pass".into());
     dkim_aligned
         .props
         .insert("header.d".into(), "example.com".into());
 
-    let mut spf_result = AuthenticationResult {
+    let spf_result = AuthenticationResult {
         method: "spf".into(),
         method_version: None,
-        result: Default::default(),
+        result: "fail".into(),
         reason: None,
         props: BTreeMap::new(),
     };
-    spf_result.props.insert("result".into(), "fail".into());
 
     let dkim_results = vec![dkim_unaligned, dkim_aligned];
     let mut dmarc_context = DmarcContext::new(
@@ -426,11 +466,10 @@ async fn dmarc_spf_ignores_non_pass_result() {
     let mut dkim_pass = AuthenticationResult {
         method: "dkim".into(),
         method_version: None,
-        result: Default::default(),
+        result: "pass".into(),
         reason: None,
         props: BTreeMap::new(),
     };
-    dkim_pass.props.insert("result".into(), "pass".into());
     dkim_pass
         .props
         .insert("header.d".into(), "example.com".into());
@@ -438,11 +477,10 @@ async fn dmarc_spf_ignores_non_pass_result() {
     let mut spf_result = AuthenticationResult {
         method: "spf".into(),
         method_version: None,
-        result: Default::default(),
+        result: "fail".into(),
         reason: None,
         props: BTreeMap::new(),
     };
-    spf_result.props.insert("result".into(), "fail".into());
     spf_result
         .props
         .insert("smtp.mailfrom".into(), "helper.example.org".into());
@@ -520,7 +558,7 @@ async fn evaluate_ip<'a>(
         props: BTreeMap::new(),
     };
     if dkim_domains.is_empty() {
-        spf_result.props.insert("result".into(), "pass".into());
+        spf_result.result = "pass".into();
         spf_result
             .props
             .insert("smtp.mailfrom".into(), mail_from_domain.into());
@@ -530,14 +568,10 @@ async fn evaluate_ip<'a>(
         let mut authentication_result = AuthenticationResult {
             method: "dkim".into(),
             method_version: None,
-            result: Default::default(),
+            result: "pass".into(),
             reason: None,
             props: BTreeMap::new(),
         };
-
-        authentication_result
-            .props
-            .insert("result".into(), "pass".into());
 
         if let Some(dkim_domain) = dkim_domain {
             authentication_result

--- a/crates/kumo-dmarc/src/types/record.rs
+++ b/crates/kumo-dmarc/src/types/record.rs
@@ -106,11 +106,11 @@ impl Record {
                 }
                 Mode::Strict => {
                     if let Some(mail_from_domain) = spf_domain {
-                        if !is_strict_aligned(cx.from_domain, mail_from_domain) {
+                        if is_strict_aligned(cx.from_domain, mail_from_domain) {
+                            cx.spf_aligned = super::results::DmarcResult::Pass;
+                        } else {
                             cx.spf_aligned = super::results::DmarcResult::Fail;
                             spf_errors.push("DMARC: SPF strict check failed".to_string());
-                        } else {
-                            cx.spf_aligned = super::results::DmarcResult::Pass;
                         }
                     }
                 }
@@ -208,14 +208,19 @@ fn spf_alignment_domain<'a>(
 
 // Relaxed alignment: organizational domain match (covers exact match too since org domain of "example.com" is "example.com")
 fn is_relaxed_aligned(from_domain: &str, signing_domain: &str) -> bool {
-    psl::domain_str(from_domain)
-        .zip(psl::domain_str(signing_domain))
-        .is_some_and(|(fd, sd)| fd.eq_ignore_ascii_case(sd))
+    let from = from_domain.trim_end_matches('.').to_ascii_lowercase();
+    let signing = signing_domain.trim_end_matches('.').to_ascii_lowercase();
+
+    psl::domain_str(&from)
+        .zip(psl::domain_str(&signing))
+        .is_some_and(|(fd, sd)| fd == sd)
 }
 
 // Strict alignment: exact domain match only.
 fn is_strict_aligned(from_domain: &str, signing_domain: &str) -> bool {
-    from_domain.eq_ignore_ascii_case(signing_domain)
+    let from = from_domain.trim_end_matches('.').to_ascii_lowercase();
+    let signing = signing_domain.trim_end_matches('.').to_ascii_lowercase();
+    from == signing
 }
 
 impl FromStr for Record {
@@ -304,6 +309,38 @@ impl FromStr for Record {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_is_strict_aligned() {
+        // Exact match, case-insensitive
+        assert!(is_strict_aligned("example.com", "example.com"));
+        assert!(is_strict_aligned("EXAMPLE.COM", "example.com"));
+        assert!(is_strict_aligned("example.com", "EXAMPLE.COM"));
+        // Trailing dot ignored
+        assert!(is_strict_aligned("example.com.", "example.com"));
+        assert!(is_strict_aligned("example.com", "example.com."));
+        assert!(is_strict_aligned("example.com.", "example.com."));
+        // Not a match
+        assert!(!is_strict_aligned("foo.example.com", "example.com"));
+        assert!(!is_strict_aligned("example.com", "foo.example.com"));
+    }
+
+    #[test]
+    fn test_is_relaxed_aligned() {
+        // Organizational domain match (covers exact match)
+        assert!(is_relaxed_aligned("example.com", "example.com"));
+        assert!(is_relaxed_aligned("foo.example.com", "example.com"));
+        assert!(is_relaxed_aligned("example.com", "foo.example.com"));
+        // Case-insensitive
+        assert!(is_relaxed_aligned("EXAMPLE.COM", "example.com"));
+        assert!(is_relaxed_aligned("foo.EXAMPLE.com", "EXAMPLE.COM"));
+        // Trailing dot ignored
+        assert!(is_relaxed_aligned("foo.example.com.", "example.com"));
+        assert!(is_relaxed_aligned("foo.example.com", "example.com."));
+        // Not a match (different org domain)
+        assert!(!is_relaxed_aligned("foo.example.org", "example.com"));
+        assert!(!is_relaxed_aligned("example.org", "example.com"));
+    }
 
     #[test]
     fn parse_b_2_1() {

--- a/crates/kumo-dmarc/src/types/record.rs
+++ b/crates/kumo-dmarc/src/types/record.rs
@@ -6,6 +6,7 @@ use crate::types::report_failure::ReportFailure;
 use crate::types::results::{Disposition, DispositionWithContext};
 use crate::{DmarcContext, SenderDomainAlignment};
 use bstr::ByteSlice;
+use mailparsing::AuthenticationResult;
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
@@ -47,7 +48,7 @@ impl Record {
         match self.align_dkim {
             Mode::Relaxed => {
                 for dkim in cx.dkim_results {
-                    if !auth_result_is_pass(&dkim.props) {
+                    if !auth_result_is_pass(&dkim) {
                         continue;
                     }
 
@@ -68,7 +69,7 @@ impl Record {
             }
             Mode::Strict => {
                 for dkim in cx.dkim_results {
-                    if !auth_result_is_pass(&dkim.props) {
+                    if !auth_result_is_pass(&dkim) {
                         continue;
                     }
 
@@ -89,7 +90,7 @@ impl Record {
             }
         }
 
-        if auth_result_is_pass(&cx.spf_result.props) {
+        if auth_result_is_pass(&cx.spf_result) {
             let spf_domain = spf_alignment_domain(&cx.spf_result.props).or(cx.mail_from_domain);
 
             match self.align_spf {
@@ -148,8 +149,8 @@ impl Record {
         }
 
         DispositionWithContext {
-            result: Disposition::Pass,
-            context: "Success".into(),
+            result: self.disposition(sender_domain_alignment),
+            context: "No aligned DKIM or SPF".into(),
             props: BTreeMap::new(),
         }
     }
@@ -185,10 +186,8 @@ impl Record {
     }
 }
 
-fn auth_result_is_pass(auth_result: &std::collections::BTreeMap<String, bstr::BString>) -> bool {
-    auth_result
-        .get("result")
-        .is_some_and(|result| result.eq_ignore_ascii_case(b"pass"))
+fn auth_result_is_pass(auth_result: &AuthenticationResult) -> bool {
+    auth_result.result.eq_ignore_ascii_case("pass")
 }
 
 fn spf_alignment_domain<'a>(

--- a/crates/kumo-dmarc/src/types/record.rs
+++ b/crates/kumo-dmarc/src/types/record.rs
@@ -5,7 +5,8 @@ use crate::types::policy::Policy;
 use crate::types::report_failure::ReportFailure;
 use crate::types::results::{Disposition, DispositionWithContext};
 use crate::{DmarcContext, SenderDomainAlignment};
-use bstr::{BStr, ByteSlice};
+use bstr::ByteSlice;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 #[derive(Debug)]
@@ -20,6 +21,7 @@ pub struct Record {
     interval: u32,
     aggregate_feedback: Vec<FeedbackAddress>,
     message_failure: Vec<FeedbackAddress>,
+    tags: BTreeMap<String, String>,
 }
 
 impl Record {
@@ -29,102 +31,126 @@ impl Record {
         dmarc_domain: &str,
         sender_domain_alignment: SenderDomainAlignment,
     ) -> DispositionWithContext {
-        let mut alignment_failure = None;
+        cx.dkim_aligned = super::results::DmarcResult::Fail;
+        cx.spf_aligned = super::results::DmarcResult::Fail;
+        let mut dkim_errors = Vec::new();
+        let mut spf_errors = Vec::new();
 
         if rand::random::<u8>() % 100 >= self.rate {
             return DispositionWithContext {
                 result: Disposition::Pass,
                 context: format!("sampled_out due to pct={}", self.rate),
+                props: BTreeMap::new(),
             };
         }
+
         match self.align_dkim {
             Mode::Relaxed => {
                 for dkim in cx.dkim_results {
-                    if let Some(result) = dkim.props.get("header.d") {
-                        let organizational_domain = psl::domain_str(cx.from_domain);
+                    if !auth_result_is_pass(&dkim.props) {
+                        continue;
+                    }
 
-                        if cx.from_domain.as_bytes() != result.as_bytes()
-                            && organizational_domain.map(BStr::new) != Some(result.as_bstr())
-                        {
-                            cx.dkim_aligned = super::results::DmarcResult::Fail;
-
-                            alignment_failure = Some(DispositionWithContext {
-                                result: self.disposition(sender_domain_alignment),
-                                context: "DMARC: DKIM relaxed check failed".into(),
-                            });
+                    if let Some(dkim_domain) = dkim.props.get("header.d") {
+                        if let Ok(dkim_domain_str) = dkim_domain.to_str() {
+                            if is_relaxed_aligned(cx.from_domain, dkim_domain_str) {
+                                dkim_errors.clear();
+                                cx.dkim_aligned = super::results::DmarcResult::Pass;
+                                break;
+                            }
                         }
+
+                        dkim_errors.push("DMARC: DKIM relaxed check failed".to_string());
                     } else {
-                        alignment_failure = Some(DispositionWithContext {
-                            result: self.disposition(sender_domain_alignment),
-                            context: "DMARC: DKIM signature missing 'd=' tag".into(),
-                        });
+                        dkim_errors.push("DMARC: DKIM signature missing 'd=' tag".to_string());
                     }
                 }
             }
             Mode::Strict => {
                 for dkim in cx.dkim_results {
-                    if let Some(result) = dkim.props.get("header.d") {
-                        if cx.from_domain != result {
-                            alignment_failure = Some(DispositionWithContext {
-                                result: self.disposition(sender_domain_alignment),
-                                context: "DMARC: DKIM strict check failed".into(),
-                            });
+                    if !auth_result_is_pass(&dkim.props) {
+                        continue;
+                    }
+
+                    if let Some(dkim_domain) = dkim.props.get("header.d") {
+                        if let Ok(dkim_domain_str) = dkim_domain.to_str() {
+                            if is_strict_aligned(cx.from_domain, dkim_domain_str) {
+                                dkim_errors.clear();
+                                cx.dkim_aligned = super::results::DmarcResult::Pass;
+                                break;
+                            }
                         }
+
+                        dkim_errors.push("DMARC: DKIM strict check failed".to_string());
                     } else {
-                        alignment_failure = Some(DispositionWithContext {
-                            result: self.disposition(sender_domain_alignment),
-                            context: "DMARC: DKIM signature missing 'd=' tag".into(),
-                        });
+                        dkim_errors.push("DMARC: DKIM signature missing 'd=' tag".to_string());
                     }
                 }
             }
         }
 
-        match self.align_spf {
-            Mode::Relaxed => {
-                if let Some(mail_from_domain) = cx.mail_from_domain {
-                    let organizational_domain = psl::domain_str(mail_from_domain);
+        if auth_result_is_pass(&cx.spf_result.props) {
+            let spf_domain = spf_alignment_domain(&cx.spf_result.props).or(cx.mail_from_domain);
 
-                    if mail_from_domain != cx.from_domain
-                        && organizational_domain != Some(cx.from_domain)
-                    {
-                        alignment_failure = Some(DispositionWithContext {
-                            result: self.disposition(sender_domain_alignment),
-                            context: "DMARC: SPF relaxed check failed".into(),
-                        });
+            match self.align_spf {
+                Mode::Relaxed => {
+                    if let Some(mail_from_domain) = spf_domain {
+                        if is_relaxed_aligned(cx.from_domain, mail_from_domain) {
+                            cx.spf_aligned = super::results::DmarcResult::Pass;
+                        } else {
+                            cx.spf_aligned = super::results::DmarcResult::Fail;
+                            spf_errors.push("DMARC: SPF relaxed check failed".to_string());
+                        }
                     }
                 }
-            }
-            Mode::Strict => {
-                if let Some(mail_from_domain) = cx.mail_from_domain {
-                    if mail_from_domain != cx.from_domain {
-                        alignment_failure = Some(DispositionWithContext {
-                            result: self.disposition(sender_domain_alignment),
-                            context: "DMARC: SPF strict check failed".into(),
-                        });
+                Mode::Strict => {
+                    if let Some(mail_from_domain) = spf_domain {
+                        if !is_strict_aligned(cx.from_domain, mail_from_domain) {
+                            cx.spf_aligned = super::results::DmarcResult::Fail;
+                            spf_errors.push("DMARC: SPF strict check failed".to_string());
+                        } else {
+                            cx.spf_aligned = super::results::DmarcResult::Pass;
+                        }
                     }
                 }
             }
         }
 
-        if let Some(alignment_failure) = alignment_failure {
+        if cx.dkim_aligned == super::results::DmarcResult::Pass
+            || cx.spf_aligned == super::results::DmarcResult::Pass
+        {
+            return DispositionWithContext {
+                result: Disposition::Pass,
+                context: "Success".into(),
+                props: BTreeMap::new(),
+            };
+        }
+
+        if let Some(alignment_context) = spf_errors
+            .into_iter()
+            .next()
+            .or_else(|| dkim_errors.into_iter().next())
+        {
+            let result = self.disposition(sender_domain_alignment);
             let _ = cx
                 .report_error(
                     self,
                     dmarc_domain,
                     sender_domain_alignment,
-                    &alignment_failure.context,
+                    &alignment_context,
                 )
                 .await;
             return DispositionWithContext {
-                result: alignment_failure.result,
-                context: alignment_failure.context,
+                result,
+                context: alignment_context,
+                props: BTreeMap::new(),
             };
         }
 
         DispositionWithContext {
             result: Disposition::Pass,
             context: "Success".into(),
+            props: BTreeMap::new(),
         }
     }
 
@@ -141,6 +167,10 @@ impl Record {
         }
     }
 
+    pub fn tags(&self) -> &BTreeMap<String, String> {
+        &self.tags
+    }
+
     fn disposition(&self, sender_domain_alignment: SenderDomainAlignment) -> Disposition {
         match sender_domain_alignment {
             SenderDomainAlignment::OrganizationalDomain => {
@@ -153,6 +183,40 @@ impl Record {
             SenderDomainAlignment::Exact => self.policy.into(),
         }
     }
+}
+
+fn auth_result_is_pass(auth_result: &std::collections::BTreeMap<String, bstr::BString>) -> bool {
+    auth_result
+        .get("result")
+        .is_some_and(|result| result.eq_ignore_ascii_case(b"pass"))
+}
+
+fn spf_alignment_domain<'a>(
+    auth_result: &'a std::collections::BTreeMap<String, bstr::BString>,
+) -> Option<&'a str> {
+    auth_result
+        .get("smtp.mailfrom")
+        .filter(|domain| !domain.is_empty())
+        .and_then(|domain| domain.to_str().ok())
+        .map(|s| s.rsplit_once('@').map_or(s, |(_, domain)| domain))
+        .or_else(|| {
+            auth_result
+                .get("smtp.helo")
+                .filter(|domain| !domain.is_empty())
+                .and_then(|domain| domain.to_str().ok())
+        })
+}
+
+// Relaxed alignment: organizational domain match (covers exact match too since org domain of "example.com" is "example.com")
+fn is_relaxed_aligned(from_domain: &str, signing_domain: &str) -> bool {
+    psl::domain_str(from_domain)
+        .zip(psl::domain_str(signing_domain))
+        .is_some_and(|(fd, sd)| fd.eq_ignore_ascii_case(sd))
+}
+
+// Strict alignment: exact domain match only.
+fn is_strict_aligned(from_domain: &str, signing_domain: &str) -> bool {
+    from_domain.eq_ignore_ascii_case(signing_domain)
 }
 
 impl FromStr for Record {
@@ -170,10 +234,16 @@ impl FromStr for Record {
             aggregate_feedback: Vec::new(),
             message_failure: Vec::new(),
             subdomain_policy: None,
+            tags: BTreeMap::new(),
         };
 
         let (mut version, mut policy) = (false, false);
         for part in s.split(';') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+
             let Some((key, value)) = part.split_once('=') else {
                 return Err(format!("invalid part {part:?}"));
             };
@@ -188,6 +258,8 @@ impl FromStr for Record {
                     _ => return Err(format!("invalid key {key:?}")),
                 }
             }
+
+            new.tags.insert(key.to_string(), value.to_string());
 
             match key {
                 "p" => {
@@ -237,7 +309,7 @@ mod tests {
     #[test]
     fn parse_b_2_1() {
         // https://www.rfc-editor.org/rfc/rfc7489#appendix-B.2.1
-        const B_2_1: &str = "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com";
+        const B_2_1: &str = "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com;";
         let record = Record::from_str(B_2_1).unwrap();
         assert_eq!(record.policy, Policy::None);
         assert_eq!(record.rate, 100);

--- a/crates/kumo-dmarc/src/types/results.rs
+++ b/crates/kumo-dmarc/src/types/results.rs
@@ -6,6 +6,7 @@ use instant_xml::{FromXml, ToXml};
 use kumo_spf::SpfDisposition;
 use mailparsing::AuthenticationResult;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::net::IpAddr;
 
@@ -179,11 +180,12 @@ impl Into<Disposition> for Policy {
 }
 
 // A synthetic type to bundle the result with a reason
-#[derive(Debug, Eq, PartialEq, ToXml, Serialize)]
-#[xml(rename_all = "lowercase")]
+#[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct DispositionWithContext {
     pub result: Disposition,
     pub context: String,
+    #[serde(default)]
+    pub props: BTreeMap<String, BString>,
 }
 
 #[derive(Debug, Eq, PartialEq, ToXml, Serialize, Deserialize, Clone)]

--- a/crates/kumo-spf/src/lib.rs
+++ b/crates/kumo-spf/src/lib.rs
@@ -139,12 +139,19 @@ pub struct CheckHostParams {
 impl CheckHostParams {
     pub async fn check(self, resolver: &dyn Resolver) -> SpfResult {
         let Self {
-            domain,
+            mut domain,
             sender,
             client_ip,
             ehlo_domain,
             relaying_host_name,
         } = self;
+
+        // When MAIL FROM is blank and domain is empty, fallback to EHLO domain
+        if domain.is_empty() {
+            if let Some(ehlo) = &ehlo_domain {
+                domain = ehlo.clone();
+            }
+        }
 
         let sender = match sender {
             Some(sender) => sender,
@@ -183,12 +190,9 @@ impl<'a> SpfContext<'a> {
     ///   initially, the domain portion of the "MAIL FROM" or "HELO" identity
     /// - `client_ip` is the IP address of the SMTP client that is emitting the mail
     fn new(sender: &'a str, domain: &'a str, client_ip: IpAddr) -> Result<Self, SpfResult> {
-        let Some((local_part, sender_domain)) = sender.rsplit_once('@') else {
-            return Err(SpfResult {
-                disposition: SpfDisposition::PermError,
-                context:
-                    "input sender parameter '{sender}' is missing @ sign to delimit local part and domain".to_owned(),
-            });
+        let (local_part, sender_domain) = match sender.rsplit_once('@') {
+            Some((local_part, sender_domain)) => (local_part, sender_domain),
+            None => ("postmaster", sender),
         };
 
         Ok(Self {

--- a/crates/kumo-spf/src/tests.rs
+++ b/crates/kumo-spf/src/tests.rs
@@ -521,6 +521,19 @@ async fn initial_processing() {
     assert_eq!(result.context, "no SPF records found for example.com");
 }
 
+#[test]
+fn helo_identity_without_at_is_accepted() {
+    let cx = SpfContext::new(
+        "mail.example.com",
+        "mail.example.com",
+        Ipv4Addr::LOCALHOST.into(),
+    )
+    .unwrap();
+
+    assert_eq!(cx.local_part, "postmaster");
+    assert_eq!(cx.sender_domain, "mail.example.com");
+}
+
 #[tokio::test]
 async fn test_exp() {
     let resolver = TestResolver::default()

--- a/crates/kumod/src/dmarc.rs
+++ b/crates/kumod/src/dmarc.rs
@@ -129,37 +129,40 @@ pub fn register<'lua>(lua: &'lua Lua) -> anyhow::Result<()> {
                 .check(&**resolver)
                 .await;
 
-                match result.result {
+                let disposition = result.result;
+                let reason = result.context;
+                let mut props = result.props;
+
+                match disposition {
                     Disposition::Pass
                     | Disposition::None
                     | Disposition::TempError
                     | Disposition::PermError => Ok(lua.to_value_with(
                         &CheckHostOutput {
-                            disposition: result.result.clone(),
+                            disposition,
                             result: AuthenticationResult {
                                 method: "dmarc".into(),
                                 method_version: None,
-                                result: result.result.to_string().to_ascii_lowercase().into(),
-                                reason: Some(result.context.into()),
-                                props: BTreeMap::default(),
+                                result: disposition.to_string().to_ascii_lowercase().into(),
+                                reason: Some(reason.into()),
+                                props,
                             },
                         },
                         serialize_options(),
                     )),
                     disp @ Disposition::Quarantine | disp @ Disposition::Reject => {
-                        let mut props = BTreeMap::default();
                         props.insert(
                             "policy.published-domain-policy".into(),
                             disp.to_string().to_ascii_lowercase().into(),
                         );
                         Ok(lua.to_value_with(
                             &CheckHostOutput {
-                                disposition: result.result.clone(),
+                                disposition,
                                 result: AuthenticationResult {
                                     method: "dmarc".into(),
                                     method_version: None,
                                     result: "fail".into(),
-                                    reason: Some(result.context.into()),
+                                    reason: Some(reason.into()),
                                     props,
                                 },
                             },


### PR DESCRIPTION
This is a redo of https://github.com/KumoCorp/kumomta/pull/505
The amount of conflict looked safer to start the PR over.

- Handle parsing failure when DMARC record ends with semicolon
- Adjust kumo.dmarc.check_msg so it considers SPF/DKIM verdict and not just alignment
- Made kumo.dmarc.check_msg to pass, if either SPF or DKIM succeeds alignment check
- Fix relax mode SPF/DKIM so the comparing hostnames considers top-level domain alignment
- Made alignment comparison case insensitive
- Added support for SPF to fallback to ehlo domain, when mail from domain is blank
- Enrich props against dkim auth_resutls for better troubleshooting capabilities
- Enrich props against dmarc auth_resutls for better troubleshooting capabilities