### PR TITLE
option to choose the first named header when calling import_x_headers

### DIFF
--- a/crates/message/src/message.rs
+++ b/crates/message/src/message.rs
@@ -1167,21 +1167,42 @@ impl Message {
         .await
     }
 
-    pub async fn import_x_headers(&self, names: Vec<String>) -> anyhow::Result<()> {
+    pub async fn import_x_headers(
+        &self,
+        names: Vec<String>,
+        first_named: bool,
+    ) -> anyhow::Result<()> {
         let data = self.data().await?;
         let HeaderParseResult { headers, .. } = Header::parse_headers(data.as_ref().as_ref())?;
 
-        for hdr in headers.iter() {
-            let do_import = if names.is_empty() {
-                is_x_header(hdr.get_name())
-            } else {
-                is_header_in_names_list(hdr.get_name(), &names)
-            };
-            if do_import {
-                let name = imported_header_name(&hdr.get_name_lossy());
-                self.set_meta(name, hdr.as_unstructured()?.to_str_lossy())
-                    .await?;
+        if first_named {
+            for hdr in headers.iter().rev() {
+                self.import_x_header_if_match(hdr, &names).await?;
             }
+        } else {
+            for hdr in headers.iter() {
+                self.import_x_header_if_match(hdr, &names).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn import_x_header_if_match(
+        &self,
+        hdr: &Header<'_>,
+        names: &[String],
+    ) -> anyhow::Result<()> {
+        let do_import = if names.is_empty() {
+            is_x_header(hdr.get_name())
+        } else {
+            is_header_in_names_list(hdr.get_name(), names)
+        };
+
+        if do_import {
+            let name = imported_header_name(&hdr.get_name_lossy());
+            self.set_meta(name, hdr.as_unstructured()?.to_str_lossy())
+                .await?;
         }
 
         Ok(())
@@ -1638,8 +1659,8 @@ impl UserData for Message {
         });
         methods.add_async_method(
             "import_x_headers",
-            |_, this, names: Option<Vec<String>>| async move {
-                this.import_x_headers(names.unwrap_or_default())
+            |_, this, (names, first_named): (Option<Vec<String>>, Option<bool>)| async move {
+                this.import_x_headers(names.unwrap_or_default(), first_named.unwrap_or(false))
                     .await
                     .map_err(any_err)
             },
@@ -1782,7 +1803,7 @@ pub(crate) mod test {
     async fn import_all_x_headers() {
         let msg = new_msg_body(X_HDR_CONTENT);
 
-        msg.import_x_headers(vec![]).await.unwrap();
+        msg.import_x_headers(vec![], false).await.unwrap();
         k9::assert_equal!(
             msg.get_meta_obj().await.unwrap(),
             json!({
@@ -1811,7 +1832,7 @@ pub(crate) mod test {
     async fn import_some_x_headers() {
         let msg = new_msg_body(X_HDR_CONTENT);
 
-        msg.import_x_headers(vec!["x-hello".to_string()])
+        msg.import_x_headers(vec!["x-hello".to_string()], false)
             .await
             .unwrap();
         k9::assert_equal!(

--- a/crates/message/test_import_x_headers.lua
+++ b/crates/message/test_import_x_headers.lua
@@ -1,0 +1,20 @@
+local kumo = require 'kumo'
+local utils = require 'policy-extras.policy_utils'
+
+local function new_msg(content)
+  return kumo.make_message('sender@example.com', 'recip@example.com', content)
+end
+
+-- HeaderAddressList: single simple address without display name
+local msg =
+  new_msg 'X-Campaign: 1234\r\nX-Campaign: 9876\r\nX-Header: test\r\nFrom: user@example.com\r\nTo: someone@example.com\r\n\r\nBody'
+
+msg:import_x_headers { 'X-Campaign' }
+
+utils.assert_eq(msg:get_meta 'x_campaign', '9876')
+
+msg:import_x_headers({ 'X-Campaign' }, true)
+utils.assert_eq(msg:get_meta 'x_campaign', '1234')
+
+msg:import_x_headers(nil, true)
+utils.assert_eq(msg:get_meta 'x_header', 'test')

--- a/docs/reference/message/import_x_headers.md
+++ b/docs/reference/message/import_x_headers.md
@@ -6,7 +6,7 @@ tags:
 # import_x_headers
 
 ```
-message:import_x_headers([NAMES])
+message:import_x_headers([NAMES], FIRST_NAMED)
 ```
 
 When called with no parameters, iterates the headers of the message, and for
@@ -20,6 +20,8 @@ as a way to import an arbitrary list of headers for logging purposes.
 
 When importing an `X-` header, the header name is normalized to lowercase and any
 `-` are transformed to underscores `_`.
+
+When a message consists of multiple headers with same name, the bottom most value is imported. Use an optional boolean paramter of `FIRST_NAMED` to import the top most header.
 
 For example, with a message content of:
 
@@ -45,4 +47,10 @@ but calling:
 message:import_x_headers { 'x-campaign-id' }
 print(message:get_meta 'x_campaign_id') -- prints 12345
 print(message:get_meta 'x_mailer') -- prints nothing
+```
+
+When choosing the top most named header
+
+```lua
+message:import_x_headers { 'x-campaign-id', true }
 ```


### PR DESCRIPTION
When there are multiple of the same header on an message, import_x_headers would prefer the bottom most value. This behavior tends to not match what mail agent would render, as mail agent would typically display the top most header. 

Add an 2nd argument when calling import_x_headers, instructing import_x_headers to prefer the top value instead of bottom.