### PR TITLE
Added support of providing static per-recipient metadata in HTTP Injection API

### DIFF
--- a/crates/integration-tests/source-rcpt-meta.lua
+++ b/crates/integration-tests/source-rcpt-meta.lua
@@ -26,15 +26,18 @@ kumo.on('init', function()
   }
 end)
 
-kumo.on('get_queue_config', function(domain, _tenant, _campaign, _routing_domain)
-  return kumo.make_queue_config {
-    protocol = {
-      smtp = {
-        mx_list = { 'localhost:' .. SINK_PORT },
+kumo.on(
+  'get_queue_config',
+  function(domain, _tenant, _campaign, _routing_domain)
+    return kumo.make_queue_config {
+      protocol = {
+        smtp = {
+          mx_list = { 'localhost:' .. SINK_PORT },
+        },
       },
-    },
-  }
-end)
+    }
+  end
+)
 
 kumo.on('get_egress_path_config', function(_domain, _source_name, _site_name)
   return kumo.make_egress_path {

--- a/crates/integration-tests/source-rcpt-meta.lua
+++ b/crates/integration-tests/source-rcpt-meta.lua
@@ -1,0 +1,44 @@
+local kumo = require 'kumo'
+
+local TEST_DIR = os.getenv 'KUMOD_TEST_DIR'
+local SINK_PORT = tonumber(os.getenv 'KUMOD_SMTP_SINK_PORT')
+
+kumo.on('init', function()
+  kumo.start_http_listener {
+    listen = '127.0.0.1:0',
+  }
+
+  -- Capture rcpt_meta into every log record so tests can assert on it.
+  kumo.configure_local_logs {
+    log_dir = TEST_DIR .. '/logs',
+    max_segment_duration = '1s',
+    meta = { 'rcpt_meta' },
+  }
+
+  kumo.define_spool {
+    name = 'data',
+    path = TEST_DIR .. '/data-spool',
+  }
+
+  kumo.define_spool {
+    name = 'meta',
+    path = TEST_DIR .. '/meta-spool',
+  }
+end)
+
+kumo.on('get_queue_config', function(domain, _tenant, _campaign, _routing_domain)
+  return kumo.make_queue_config {
+    protocol = {
+      smtp = {
+        mx_list = { 'localhost:' .. SINK_PORT },
+      },
+    },
+  }
+end)
+
+kumo.on('get_egress_path_config', function(_domain, _source_name, _site_name)
+  return kumo.make_egress_path {
+    enable_tls = 'OpportunisticInsecure',
+    prohibited_hosts = {},
+  }
+end)

--- a/crates/integration-tests/src/test/http_inject_rcpt_meta.rs
+++ b/crates/integration-tests/src/test/http_inject_rcpt_meta.rs
@@ -151,7 +151,11 @@ async fn per_recipient_metadata_multiple_recipients() -> anyhow::Result<()> {
         .iter()
         .filter(|r| r.kind == RecordType::Delivery)
         .collect();
-    anyhow::ensure!(deliveries.len() == 2, "expected 2 Delivery records, got {}", deliveries.len());
+    anyhow::ensure!(
+        deliveries.len() == 2,
+        "expected 2 Delivery records, got {}",
+        deliveries.len()
+    );
 
     // Match each delivery record to its recipient by address.
     let find_delivery = |addr: &str| {
@@ -166,16 +170,28 @@ async fn per_recipient_metadata_multiple_recipients() -> anyhow::Result<()> {
         .meta
         .get("rcpt_meta")
         .context("rcpt_meta missing from alice's Delivery record")?;
-    assert_equal!(alice_meta.get("campaign").and_then(|v| v.as_str()), Some("summer-sale"));
-    assert_equal!(alice_meta.get("segment").and_then(|v| v.as_str()), Some("vip"));
+    assert_equal!(
+        alice_meta.get("campaign").and_then(|v| v.as_str()),
+        Some("summer-sale")
+    );
+    assert_equal!(
+        alice_meta.get("segment").and_then(|v| v.as_str()),
+        Some("vip")
+    );
 
     let bob = find_delivery("bob")?;
     let bob_meta = bob
         .meta
         .get("rcpt_meta")
         .context("rcpt_meta missing from bob's Delivery record")?;
-    assert_equal!(bob_meta.get("campaign").and_then(|v| v.as_str()), Some("newsletter"));
-    assert_equal!(bob_meta.get("segment").and_then(|v| v.as_str()), Some("standard"));
+    assert_equal!(
+        bob_meta.get("campaign").and_then(|v| v.as_str()),
+        Some("newsletter")
+    );
+    assert_equal!(
+        bob_meta.get("segment").and_then(|v| v.as_str()),
+        Some("standard")
+    );
 
     Ok(())
 }

--- a/crates/integration-tests/src/test/http_inject_rcpt_meta.rs
+++ b/crates/integration-tests/src/test/http_inject_rcpt_meta.rs
@@ -1,0 +1,235 @@
+use crate::kumod::DaemonWithMaildirOptions;
+use anyhow::Context;
+use k9::assert_equal;
+use kumo_log_types::RecordType;
+use std::time::Duration;
+
+fn daemon_opts() -> DaemonWithMaildirOptions {
+    DaemonWithMaildirOptions::new().policy_file("source-rcpt-meta.lua")
+}
+
+/// Inject a message with per-recipient metadata and verify that:
+/// 1. rcpt_meta is stored on the message (accessible from Lua via msg:get_meta)
+/// 2. rcpt_meta is captured into log records via configure_local_logs's meta list
+///
+/// This exercises the full path: HTTP request → make_message stores rcpt_meta
+/// → delivery → Delivery log record contains rcpt_meta with the original key-value pairs.
+#[tokio::test]
+async fn rcpt_meta_is_captured_in_logs() -> anyhow::Result<()> {
+    let mut daemon = daemon_opts()
+        .start()
+        .await
+        .context("DaemonWithMaildir::start")?;
+
+    let payload = serde_json::json!({
+        "envelope_sender": "sender@example.com",
+        "recipients": [{
+            "email": "user@example.com",
+            "metadata": {
+                "campaign": "promo-2026-q2",
+                "segment": "premium"
+            }
+        }],
+        "content": {
+            "subject": "Rcpt Meta Log Test",
+            "text_body": "Hello!"
+        }
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&format!(
+            "http://{}/api/inject/v1",
+            daemon.source.listener("http")
+        ))
+        .json(&payload)
+        .send()
+        .await?;
+
+    anyhow::ensure!(
+        response.status() == 200,
+        "Expected 200, got {}",
+        response.status()
+    );
+    let body: serde_json::Value = response.json().await?;
+    assert_equal!(body["success_count"], 1);
+    assert_equal!(body["fail_count"], 0);
+
+    daemon
+        .wait_for_maildir_count(1, Duration::from_secs(10))
+        .await;
+
+    // Stop before reading logs — kumod flushes log segments on shutdown.
+    daemon.stop_both().await.context("stop_both")?;
+
+    // Read source log records and find the Delivery entry.
+    let logs = daemon.source.collect_logs().await?;
+    let delivery = logs
+        .iter()
+        .find(|r| r.kind == RecordType::Delivery)
+        .context("no Delivery log record found")?;
+
+    // rcpt_meta must be present and contain the key-value pairs we injected.
+    let rcpt_meta = delivery
+        .meta
+        .get("rcpt_meta")
+        .context("rcpt_meta is missing from the Delivery log record")?;
+
+    assert_equal!(
+        rcpt_meta.get("campaign").and_then(|v| v.as_str()),
+        Some("promo-2026-q2")
+    );
+    assert_equal!(
+        rcpt_meta.get("segment").and_then(|v| v.as_str()),
+        Some("premium")
+    );
+
+    Ok(())
+}
+
+/// Inject two recipients with distinct metadata and verify that each Delivery
+/// log record carries only its own rcpt_meta — metadata must not bleed across
+/// recipients.
+#[tokio::test]
+async fn per_recipient_metadata_multiple_recipients() -> anyhow::Result<()> {
+    let mut daemon = daemon_opts()
+        .start()
+        .await
+        .context("DaemonWithMaildir::start")?;
+
+    let payload = serde_json::json!({
+        "envelope_sender": "sender@example.com",
+        "recipients": [
+            {
+                "email": "alice@example.com",
+                "metadata": {
+                    "campaign": "summer-sale",
+                    "segment": "vip"
+                }
+            },
+            {
+                "email": "bob@example.com",
+                "metadata": {
+                    "campaign": "newsletter",
+                    "segment": "standard"
+                }
+            }
+        ],
+        "content": {
+            "subject": "Per-Recipient Meta Test",
+            "text_body": "Hello!"
+        }
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&format!(
+            "http://{}/api/inject/v1",
+            daemon.source.listener("http")
+        ))
+        .json(&payload)
+        .send()
+        .await?;
+
+    anyhow::ensure!(
+        response.status() == 200,
+        "Expected 200, got {}",
+        response.status()
+    );
+    let body: serde_json::Value = response.json().await?;
+    assert_equal!(body["success_count"], 2);
+    assert_equal!(body["fail_count"], 0);
+
+    daemon
+        .wait_for_maildir_count(2, Duration::from_secs(10))
+        .await;
+
+    daemon.stop_both().await.context("stop_both")?;
+
+    let logs = daemon.source.collect_logs().await?;
+    let deliveries: Vec<_> = logs
+        .iter()
+        .filter(|r| r.kind == RecordType::Delivery)
+        .collect();
+    anyhow::ensure!(deliveries.len() == 2, "expected 2 Delivery records, got {}", deliveries.len());
+
+    // Match each delivery record to its recipient by address.
+    let find_delivery = |addr: &str| {
+        deliveries
+            .iter()
+            .find(|r| r.recipient.iter().any(|a| a.contains(addr)))
+            .with_context(|| format!("no Delivery record for {addr}"))
+    };
+
+    let alice = find_delivery("alice")?;
+    let alice_meta = alice
+        .meta
+        .get("rcpt_meta")
+        .context("rcpt_meta missing from alice's Delivery record")?;
+    assert_equal!(alice_meta.get("campaign").and_then(|v| v.as_str()), Some("summer-sale"));
+    assert_equal!(alice_meta.get("segment").and_then(|v| v.as_str()), Some("vip"));
+
+    let bob = find_delivery("bob")?;
+    let bob_meta = bob
+        .meta
+        .get("rcpt_meta")
+        .context("rcpt_meta missing from bob's Delivery record")?;
+    assert_equal!(bob_meta.get("campaign").and_then(|v| v.as_str()), Some("newsletter"));
+    assert_equal!(bob_meta.get("segment").and_then(|v| v.as_str()), Some("standard"));
+
+    Ok(())
+}
+
+/// When no metadata field is supplied, rcpt_meta must be absent from the log
+/// record — the meta entry should simply not exist.
+#[tokio::test]
+async fn absent_metadata_is_not_in_logs() -> anyhow::Result<()> {
+    let mut daemon = daemon_opts()
+        .start()
+        .await
+        .context("DaemonWithMaildir::start")?;
+
+    let payload = serde_json::json!({
+        "envelope_sender": "sender@example.com",
+        "recipients": [{
+            "email": "user@example.com"
+        }],
+        "content": {
+            "subject": "No Metadata Test",
+            "text_body": "Hello!"
+        }
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&format!(
+            "http://{}/api/inject/v1",
+            daemon.source.listener("http")
+        ))
+        .json(&payload)
+        .send()
+        .await?;
+
+    anyhow::ensure!(response.status() == 200, "Expected 200");
+    let body: serde_json::Value = response.json().await?;
+    assert_equal!(body["success_count"], 1);
+
+    daemon
+        .wait_for_maildir_count(1, Duration::from_secs(10))
+        .await;
+
+    daemon.stop_both().await.context("stop_both")?;
+
+    let logs = daemon.source.collect_logs().await?;
+    let delivery = logs
+        .iter()
+        .find(|r| r.kind == RecordType::Delivery)
+        .context("no Delivery log record found")?;
+
+    assert!(
+        delivery.meta.get("rcpt_meta").is_none(),
+        "rcpt_meta must be absent when no metadata was supplied"
+    );
+
+    Ok(())
+}

--- a/crates/integration-tests/src/test/mod.rs
+++ b/crates/integration-tests/src/test/mod.rs
@@ -21,6 +21,7 @@ mod expires;
 mod http_auth;
 mod http_inject_compression;
 mod http_inject_deferred;
+mod http_inject_rcpt_meta;
 mod http_inject_size_limit;
 mod http_inject_template_syntax_error;
 mod http_liveness;

--- a/crates/kumod/src/http_server/inject_v1.rs
+++ b/crates/kumod/src/http_server/inject_v1.rs
@@ -825,9 +825,7 @@ async fn make_message<'a>(
         message
             .set_meta(
                 "rcpt_meta",
-                serde_json::Value::Object(
-                    recip.metadata.clone().into_iter().collect(),
-                ),
+                serde_json::Value::Object(recip.metadata.clone().into_iter().collect()),
             )
             .await?;
     }

--- a/crates/kumod/src/http_server/inject_v1.rs
+++ b/crates/kumod/src/http_server/inject_v1.rs
@@ -129,6 +129,15 @@ pub struct Recipient {
         "gender": "male",
     }))]
     pub substitutions: HashMap<String, Value>,
+
+    /// Per-recipient metadata key-value pairs that will be stored in the
+    /// message's `rcpt_meta` metadata field.
+    #[serde(default)]
+    #[schema(additional_properties, example=json!({
+        "campaign_id": "promo-2026-q2",
+        "user_segment": "premium",
+    }))]
+    pub metadata: HashMap<String, Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
@@ -812,6 +821,11 @@ async fn make_message<'a>(
     if let Some(hostname) = hostname {
         message.set_meta("hostname", hostname.to_string()).await?;
     }
+    if !recip.metadata.is_empty() {
+        message
+            .set_meta("rcpt_meta", serde_json::to_value(&recip.metadata)?)
+            .await?;
+    }
     Ok(message)
 }
 
@@ -1447,6 +1461,7 @@ This is a test message to {{ name }}, with some 👻🍉💩 emoji!
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Rfc822(input.to_string()),
@@ -1496,6 +1511,7 @@ This is a test message to {{ name }}, with some 👻🍉💩 emoji!
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Rfc822(input.to_string()),
@@ -1539,6 +1555,7 @@ This is a test message to James Smythe, with some =F0=9F=91=BB=F0=9F=8D=89=\r
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Builder {
@@ -1624,6 +1641,7 @@ Some(
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Builder {
@@ -1719,6 +1737,7 @@ Ok(
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Builder {
@@ -1818,6 +1837,7 @@ Some(
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Builder {
@@ -1889,6 +1909,7 @@ Some(
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Builder {
@@ -1960,6 +1981,7 @@ Some(
                     email: "user@example.com".to_string(),
                     name: Some("James Smythe".to_string()),
                     substitutions: HashMap::new(),
+                    metadata: HashMap::new(),
                 },
                 Recipient {
                     email: "second@example.com".to_string(),
@@ -1970,6 +1992,7 @@ Some(
                     )]
                     .into_iter()
                     .collect(),
+                    metadata: HashMap::new(),
                 },
             ],
             substitutions: HashMap::new(),
@@ -2072,6 +2095,7 @@ Some(
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Builder {
@@ -2149,6 +2173,7 @@ Some(
                 email: "user@example.com".to_string(),
                 name: Some("James Smythe".to_string()),
                 substitutions: HashMap::new(),
+                metadata: HashMap::new(),
             }],
             substitutions: HashMap::new(),
             content: Content::Builder {

--- a/crates/kumod/src/http_server/inject_v1.rs
+++ b/crates/kumod/src/http_server/inject_v1.rs
@@ -823,7 +823,12 @@ async fn make_message<'a>(
     }
     if !recip.metadata.is_empty() {
         message
-            .set_meta("rcpt_meta", serde_json::to_value(&recip.metadata)?)
+            .set_meta(
+                "rcpt_meta",
+                serde_json::Value::Object(
+                    recip.metadata.clone().into_iter().collect(),
+                ),
+            )
             .await?;
     }
     Ok(message)

--- a/docs/changelog/main.md
+++ b/docs/changelog/main.md
@@ -4,6 +4,11 @@
 
 ## Other Changes and Enhancements
 
+ * The HTTP injection API now supports per-recipient metadata via a new
+   `metadata` field on each recipient object. Key-value pairs supplied
+   there are stored in the message's `rcpt_meta` metadata field, making
+   them accessible in Lua hooks using `msg:get_meta('rcpt_meta')`
+
 ## Fixes
 
  * A message with multipart/mixed as the root with multipart/related as a child

--- a/docs/reference/http/kumod/schemas/Recipient.md
+++ b/docs/reference/http/kumod/schemas/Recipient.md
@@ -30,6 +30,11 @@ This is an object value, with the following properties:
     |name|Populated from the recipient `name` field|Always|
     |to_header|A suitable value for use in a `To:` header, constructed from the recipient `email` and `name` fields. eg: `"John Smith" <john.smith@mailbox-example.com>`|{{since('2026.04.09-ea3b2a9b', inline=True)}}|
 
+  * `metadata` - optional `object`. {{since('dev', inline=True)}} Per-recipient metadata
+    key-value pairs that will be stored in the message's `rcpt_meta` metadata field.
+    These values are preserved through the message lifecycle and are accessible in
+    Lua hooks via `msg:get_meta('rcpt_meta')`
+
 ### Examples
 ```json
 {
@@ -38,6 +43,10 @@ This is an object value, with the following properties:
   "substitutions": {
     "age": 42,
     "gender": "male"
+  },
+  "metadata": {
+    "campaign_id": "promo-2026-q2",
+    "user_segment": "premium"
   }
 }
 ```


### PR DESCRIPTION
Adds a metadata field to the Recipient object in the HTTP injection API. Key-value pairs supplied in this field are stored in the message's rcpt_meta metadata entry, making them accessible throughout the message lifecycle via `msg:get_meta('rcpt_meta')` in Lua policy hooks.    
This enables us to include this metadata in ways like 
- Supplemental Trace Headers 
   ```
   kumo.apply_supplemental_trace_header(msg, {
     supplemental_header = true,
     header_name = 'X-KumoRef',
     include_meta_names = {'rcpt_meta'},
   })
   ```
   Or directly in the request payload using its `trace_headers` field. 
   ```
   {
   "trace_headers": {
     "received_header": false,
     "supplemental_header": true,
     "header_name": "X-KumoRef",
     "include_meta_names": {'rcpt_meta'},
    },
  }
   ```
   
- Webhook Events and Logs
  ```
  kumo.configure_local_logs {
     log_dir = '/var/log/kumomta',
     meta = { 'rcpt_meta' },
  }
  ```

and in various other forms of custom logic without using substitutions and thus improving performance for the case where there are a large number of metadata variables per recipient. 

I have added an integration test for one of the possible use-cases. 