### PR TITLE
Report matched TSA automation regex in reasons

### DIFF
--- a/crates/kumo-api-types/src/shaping.rs
+++ b/crates/kumo-api-types/src/shaping.rs
@@ -241,19 +241,38 @@ pub struct Rule {
 }
 
 impl Rule {
-    pub fn matches(&self, is_internal: bool, response: &str) -> bool {
+    pub fn matched_regex(&self, is_internal: bool, response: &str) -> Option<&Regex> {
         if is_internal && !self.match_internal {
-            return false;
+            return None;
         }
         self.regex
             .iter()
-            .any(|r| r.is_match(response).unwrap_or(false))
+            .find(|r| r.is_match(response).unwrap_or(false))
+    }
+
+    pub fn matches(&self, is_internal: bool, response: &str) -> bool {
+        self.matched_regex(is_internal, response).is_some()
     }
 
     pub fn clone_and_set_rollup(&self) -> Self {
         let mut result = self.clone();
         result.was_rollup = true;
         result
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct MatchedRule {
+    pub rule: Rule,
+    pub matched_regex: String,
+}
+
+impl MatchedRule {
+    fn new(rule: Rule, matched_regex: String) -> Self {
+        Self {
+            rule,
+            matched_regex,
+        }
     }
 }
 
@@ -341,7 +360,7 @@ impl ShapingInner {
         params
     }
 
-    pub async fn match_rules(&self, record: &JsonLogRecord) -> anyhow::Result<Vec<Rule>> {
+    pub async fn match_rules(&self, record: &JsonLogRecord) -> anyhow::Result<Vec<MatchedRule>> {
         use rfc5321::parser::ForwardPath;
         // Extract the domain from the recipient.
         let recipient = ForwardPath::try_from(
@@ -391,7 +410,7 @@ impl ShapingInner {
         record: &JsonLogRecord,
         domain: &str,
         site_name: &str,
-    ) -> Vec<Rule> {
+    ) -> Vec<MatchedRule> {
         let mut result = vec![];
         let response = record.response.to_single_line();
         tracing::trace!("Consider rules for {response}");
@@ -401,14 +420,15 @@ impl ShapingInner {
         if let Some(default) = self.by_domain.get("default") {
             for rule in &default.automation {
                 tracing::trace!("Consider \"default\" rule {rule:?} for {response}");
-                if rule.matches(is_internal, &response) {
+                if let Some(matched_regex) = rule.matched_regex(is_internal, &response) {
+                    let matched_regex = matched_regex.to_string();
                     // For automation under `default`, we always
                     // assume that mx_rollup should be true.
                     // If you somehow have a domain where that isn't
                     // true, you should avoid using `default` for
                     // automation.  Honestly, it's best to avoid
                     // using `default` for automation.
-                    result.push(rule.clone_and_set_rollup());
+                    result.push(MatchedRule::new(rule.clone_and_set_rollup(), matched_regex));
                 }
             }
         }
@@ -420,8 +440,9 @@ impl ShapingInner {
                         "Consider provider \"{}\" rule {rule:?} for {response}",
                         prov.provider_name
                     );
-                    if rule.matches(is_internal, &response) {
-                        result.push(rule.clone());
+                    if let Some(matched_regex) = rule.matched_regex(is_internal, &response) {
+                        let matched_regex = matched_regex.to_string();
+                        result.push(MatchedRule::new(rule.clone(), matched_regex));
                     }
                 }
             }
@@ -431,8 +452,9 @@ impl ShapingInner {
         if let Some(by_site) = self.by_site.get(site_name) {
             for rule in &by_site.automation {
                 tracing::trace!("Consider \"{site_name}\" rule {rule:?} for {response}");
-                if rule.matches(is_internal, &response) {
-                    result.push(rule.clone_and_set_rollup());
+                if let Some(matched_regex) = rule.matched_regex(is_internal, &response) {
+                    let matched_regex = matched_regex.to_string();
+                    result.push(MatchedRule::new(rule.clone_and_set_rollup(), matched_regex));
                 }
             }
         }
@@ -441,8 +463,9 @@ impl ShapingInner {
         if let Some(by_domain) = self.by_domain.get(domain) {
             for rule in &by_domain.automation {
                 tracing::trace!("Consider \"{domain}\" rule {rule:?} for {response}");
-                if rule.matches(is_internal, &response) {
-                    result.push(rule.clone());
+                if let Some(matched_regex) = rule.matched_regex(is_internal, &response) {
+                    let matched_regex = matched_regex.to_string();
+                    result.push(MatchedRule::new(rule.clone(), matched_regex));
                 }
             }
         }
@@ -937,7 +960,7 @@ impl Shaping {
         &self.inner.warnings
     }
 
-    pub async fn match_rules(&self, record: &JsonLogRecord) -> anyhow::Result<Vec<Rule>> {
+    pub async fn match_rules(&self, record: &JsonLogRecord) -> anyhow::Result<Vec<MatchedRule>> {
         self.inner.match_rules(record).await
     }
 
@@ -1002,7 +1025,7 @@ impl LuaUserData for Shaping {
             let rules = this.match_rules(&record).await.map_err(any_err)?;
             let mut result = vec![];
             for rule in rules {
-                result.push(lua.to_value(&rule)?);
+                result.push(lua.to_value(&rule.rule)?);
             }
             Ok(result)
         });
@@ -1741,6 +1764,18 @@ action = {SetConfig={name="connection_limit", value=3}}
 duration = "1hr"
 match_internal = true
 
+["multi.example"]
+mx_rollup = false
+
+[["multi.example".automation]]
+regex=[
+  "first pattern",
+  "second pattern",
+  "third pattern"
+]
+action = "Suspend"
+duration = "1hr"
+
 "#])
         .await;
 
@@ -1788,7 +1823,7 @@ match_internal = true
             .await
             .unwrap();
         k9::assert_equal!(
-            matches[0].regex[0].to_string(),
+            matches[0].rule.regex[0].to_string(),
             "default",
             "matches against default automation rule"
         );
@@ -1812,7 +1847,7 @@ match_internal = true
             .await
             .unwrap();
         k9::assert_equal!(
-            matches[0].regex[0].to_string(),
+            matches[0].rule.regex[0].to_string(),
             "woot_domain",
             "matches against domain rule with mx_rollup=false"
         );
@@ -1822,7 +1857,7 @@ match_internal = true
             .await
             .unwrap();
         k9::assert_equal!(
-            matches[0].regex[0].to_string(),
+            matches[0].rule.regex[0].to_string(),
             "fake_rollup",
             "matches against domain rule with mx_rollup=true"
         );
@@ -1832,7 +1867,7 @@ match_internal = true
             .await
             .unwrap();
         k9::assert_equal!(
-            matches[0].regex[0].to_string(),
+            matches[0].rule.regex[0].to_string(),
             "provider",
             "matches against provider rule"
         );
@@ -1846,9 +1881,28 @@ match_internal = true
             .await
             .unwrap();
         k9::assert_equal!(
-            matches[0].regex[0].to_string(),
+            matches[0].rule.regex[0].to_string(),
             "provider",
             "internal response matches against provider rule"
+        );
+
+        let matches = shaping
+            .match_rules(&make_record(
+                "smtp replied with second pattern",
+                "user@multi.example",
+                "dummy_site",
+            ))
+            .await
+            .unwrap();
+        k9::assert_equal!(
+            matches[0].matched_regex,
+            "second pattern",
+            "records the regex that matched without losing the full rule"
+        );
+        k9::assert_equal!(
+            matches[0].rule.regex.len(),
+            3,
+            "keeps the full rule available for hashing and action handling"
         );
     }
 

--- a/crates/mod-counter-series/src/lib.rs
+++ b/crates/mod-counter-series/src/lib.rs
@@ -58,11 +58,7 @@ impl UserData for LuaCounterSeries {
 /// non-zero sub-second component is rounded up to the next full second.
 fn round_up_to_seconds(d: Duration) -> u64 {
     let secs = d.as_secs();
-    if d.subsec_nanos() > 0 {
-        secs + 1
-    } else {
-        secs
-    }
+    if d.subsec_nanos() > 0 { secs + 1 } else { secs }
 }
 
 fn make_config(num_buckets: u8, bucket_size_seconds: u64) -> mlua::Result<CounterSeriesConfig> {

--- a/crates/tsa-daemon/src/http_server.rs
+++ b/crates/tsa-daemon/src/http_server.rs
@@ -11,7 +11,7 @@ use axum::response::IntoResponse;
 use axum::Json;
 use chrono::{DateTime, Utc};
 use kumo_api_types::shaping::{
-    Action, EgressPathConfigValueUnchecked, Regex, Rule, Shaping, Trigger,
+    Action, EgressPathConfigValueUnchecked, MatchedRule, Rule, Shaping, Trigger,
 };
 use kumo_api_types::tsa::{
     ReadyQSuspension, SchedQBounce, SchedQSuspension, SubscriptionItem, SuspensionEntry,
@@ -61,22 +61,6 @@ pub enum PreferRollup {
     No,
 }
 
-pub fn regex_list_to_string(list: &[Regex]) -> String {
-    if list.len() == 1 {
-        list[0].to_string()
-    } else {
-        let mut result = "(".to_string();
-        for (n, r) in list.iter().enumerate() {
-            if n > 0 {
-                result.push(',');
-            }
-            result.push_str(&r.to_string());
-        }
-        result.push(')');
-        result
-    }
-}
-
 #[derive(PartialEq, Clone, Copy)]
 enum UseCampaign {
     Yes,
@@ -92,6 +76,7 @@ enum UseTenant {
 async fn create_bounce(
     action_hash: &ActionHash,
     rule: &Rule,
+    matched_regex: &str,
     record: &JsonLogRecord,
     use_tenant: UseTenant,
     use_campaign: UseCampaign,
@@ -119,8 +104,7 @@ async fn create_bounce(
     };
     let mut reason = format!(
         "automation rule: {} domain={}",
-        regex_list_to_string(&rule.regex),
-        components.domain
+        matched_regex, components.domain
     );
     if let Some(tenant) = &tenant {
         reason.push_str(&format!(" tenant={tenant}"));
@@ -162,6 +146,7 @@ async fn create_tenant_suspension(
     action_hash: &ActionHash,
     rule_hash: &str,
     rule: &Rule,
+    matched_regex: &str,
     record: &JsonLogRecord,
     use_campaign: UseCampaign,
     events: &mut Vec<SubscriptionItem>,
@@ -184,8 +169,7 @@ async fn create_tenant_suspension(
     let expires = record.timestamp + chrono::Duration::from_std(rule.duration)?;
     let mut reason = format!(
         "automation rule: {} tenant={tenant} domain={}",
-        regex_list_to_string(&rule.regex),
-        components.domain
+        matched_regex, components.domain
     );
     if let Some(campaign) = &campaign {
         reason.push_str(&format!(" campaign={campaign}"));
@@ -227,12 +211,13 @@ async fn create_ready_q_suspension(
     action_hash: &ActionHash,
     rule_hash: &str,
     rule: &Rule,
+    matched_regex: &str,
     record: &JsonLogRecord,
     source: &str,
     events: &mut Vec<SubscriptionItem>,
 ) -> anyhow::Result<()> {
     let expires = record.timestamp + chrono::Duration::from_std(rule.duration)?;
-    let reason = format!("automation rule: {}", regex_list_to_string(&rule.regex));
+    let reason = format!("automation rule: {matched_regex}");
 
     {
         let reason = reason.to_string();
@@ -313,21 +298,25 @@ async fn publish_log_v1_impl(
         let matches = shaping.match_rules(&record).await?;
 
         for m in &matches {
-            let expires = record.timestamp + chrono::Duration::from_std(m.duration)?;
+            let MatchedRule {
+                rule,
+                matched_regex,
+            } = m;
+            let expires = record.timestamp + chrono::Duration::from_std(rule.duration)?;
             if expires <= *now {
                 // Record was perhaps delayed and is already expired, no sense recording it now
                 continue;
             }
 
-            let matching_scope = MatchingScope::from_rule_and_record(m, &record);
+            let matching_scope = MatchingScope::from_rule_and_record(rule, &record);
 
-            let triggered = match m.trigger {
+            let triggered = match rule.trigger {
                 Trigger::Immediate => true,
                 Trigger::Threshold(spec) => {
                     let count = TSA_STATE
                         .get()
                         .expect("state not initialized")
-                        .record_event(&matching_scope, m, &record);
+                        .record_event(&matching_scope, rule, &record);
 
                     count >= spec.limit
                 }
@@ -338,14 +327,14 @@ async fn publish_log_v1_impl(
             // To enact the action, we need to generate (or update) a row
             // in the db with its effects and its expiry
             if triggered {
-                for action in &m.action {
+                for action in &rule.action {
                     // Since there can be multiple actions within a match,
                     // ensure that the rule_hash that we use to record
                     // the effects of an action varies by the current
                     // action that we are iterating
-                    let a_hash = action_hash(m, action);
+                    let a_hash = action_hash(rule, action);
                     let rule_hash = format!("{store_key}-{a_hash}");
-                    let action_hash = ActionHash::from_rule_and_record(m, action, &record);
+                    let action_hash = ActionHash::from_rule_and_record(rule, action, &record);
 
                     tracing::debug!("{action:?} for {record:?}");
                     match action {
@@ -353,7 +342,8 @@ async fn publish_log_v1_impl(
                             create_ready_q_suspension(
                                 &action_hash,
                                 &rule_hash,
-                                m,
+                                rule,
+                                matched_regex,
                                 &record,
                                 source,
                                 events,
@@ -364,7 +354,8 @@ async fn publish_log_v1_impl(
                             create_tenant_suspension(
                                 &action_hash,
                                 &rule_hash,
-                                m,
+                                rule,
+                                matched_regex,
                                 &record,
                                 UseCampaign::No,
                                 events,
@@ -375,7 +366,8 @@ async fn publish_log_v1_impl(
                             create_tenant_suspension(
                                 &action_hash,
                                 &rule_hash,
-                                m,
+                                rule,
+                                matched_regex,
                                 &record,
                                 UseCampaign::Yes,
                                 events,
@@ -388,7 +380,8 @@ async fn publish_log_v1_impl(
                                 .expect("tsa_state missing")
                                 .create_config_override(
                                     &action_hash,
-                                    m,
+                                    rule,
+                                    matched_regex,
                                     &record,
                                     config,
                                     &domain,
@@ -402,7 +395,8 @@ async fn publish_log_v1_impl(
                                 .expect("tsa_state missing")
                                 .create_config_override(
                                     &action_hash,
-                                    m,
+                                    rule,
+                                    matched_regex,
                                     &record,
                                     config,
                                     &domain,
@@ -413,7 +407,8 @@ async fn publish_log_v1_impl(
                         Action::Bounce => {
                             create_bounce(
                                 &action_hash,
-                                m,
+                                rule,
+                                matched_regex,
                                 &record,
                                 UseTenant::No,
                                 UseCampaign::No,
@@ -424,7 +419,8 @@ async fn publish_log_v1_impl(
                         Action::BounceTenant => {
                             create_bounce(
                                 &action_hash,
-                                m,
+                                rule,
+                                matched_regex,
                                 &record,
                                 UseTenant::Yes,
                                 UseCampaign::No,
@@ -435,7 +431,8 @@ async fn publish_log_v1_impl(
                         Action::BounceCampaign => {
                             create_bounce(
                                 &action_hash,
-                                m,
+                                rule,
+                                matched_regex,
                                 &record,
                                 UseTenant::Yes,
                                 UseCampaign::Yes,

--- a/crates/tsa-daemon/src/state.rs
+++ b/crates/tsa-daemon/src/state.rs
@@ -1,7 +1,6 @@
 use crate::http_server::{
     import_bounces_from_sqlite, import_configs_from_sqlite, import_suspensions_from_sqlite,
-    open_history_db, regex_list_to_string, toml_to_toml_edit_value, PreferRollup, Sha256Hasher,
-    DB_PATH,
+    open_history_db, toml_to_toml_edit_value, PreferRollup, Sha256Hasher, DB_PATH,
 };
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -242,13 +241,14 @@ impl TsaState {
         &self,
         scope: &ActionHash,
         rule: &Rule,
+        matched_regex: &str,
         record: &JsonLogRecord,
         config: &EgressPathConfigValue,
         domain: &str,
         source: &str,
         prefer_rollup: PreferRollup,
     ) {
-        let reason = format!("automation rule: {}", regex_list_to_string(&rule.regex));
+        let reason = format!("automation rule: {matched_regex}");
         self.insert_config_override(
             scope.clone(),
             ConfigurationOverride {
@@ -902,5 +902,95 @@ pub async fn state_pruner() -> anyhow::Result<()> {
             }
             last_save = Instant::now();
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use kumo_api_types::shaping::{Regex, Trigger};
+    use serde_json::json;
+
+    fn make_record(timestamp: DateTime<Utc>) -> JsonLogRecord {
+        serde_json::from_value(json!({
+            "type": "TransientFailure",
+            "id": "",
+            "sender": "",
+            "recipient": "user@example.com",
+            "queue": "",
+            "site": "example.com",
+            "size": 0,
+            "response": {
+                "code": 400,
+                "content": "smtp replied with second pattern",
+                "command": null,
+                "enhanced_code": null
+            },
+            "peer_address": null,
+            "timestamp": timestamp.timestamp(),
+            "event_time": timestamp,
+            "created": timestamp.timestamp(),
+            "created_time": timestamp,
+            "num_attempts": 1,
+            "bounce_classification": "Uncategorized",
+            "egress_pool": null,
+            "egress_source": null,
+            "source_address": null,
+            "feedback_report": null,
+            "meta": {},
+            "headers": {},
+            "delivery_protocol": null,
+            "reception_protocol": null,
+            "nodeid": "00000000-0000-0000-0000-000000000000",
+            "tls_cipher": null,
+            "tls_protocol_version": null,
+            "tls_peer_subject_name": null,
+            "provider_name": null,
+            "session_id": null
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn config_override_reason_uses_matched_regex() {
+        let config: EgressPathConfigValue = EgressPathConfigValueUnchecked {
+            name: "connection_limit".to_string(),
+            value: toml::Value::Integer(1),
+        }
+        .try_into()
+        .unwrap();
+        let rule = Rule {
+            regex: vec![
+                Regex::try_from("first pattern".to_string()).unwrap(),
+                Regex::try_from("second pattern".to_string()).unwrap(),
+                Regex::try_from("third pattern".to_string()).unwrap(),
+            ],
+            action: vec![Action::SetConfig(config.clone())],
+            trigger: Trigger::Immediate,
+            duration: std::time::Duration::from_secs(3600),
+            was_rollup: false,
+            match_internal: false,
+        };
+        let record = make_record(Utc::now());
+        let action_hash = ActionHash::from_rule_and_record(&rule, &rule.action[0], &record);
+        let state = TsaState::default();
+
+        state.create_config_override(
+            &action_hash,
+            &rule,
+            "second pattern",
+            &record,
+            &config,
+            "example.com",
+            "unspecified",
+            PreferRollup::No,
+        );
+
+        let over = state.config_overrides.get(&action_hash).unwrap();
+        assert_eq!(
+            over.reason.as_str(),
+            "automation rule: second pattern",
+            "uses only the matched regex in automation reasons"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- carry the regex that matched a TSA automation rule out of the existing rule scan
- use that matched regex in generated suspension, bounce, and config override reasons
- keep the full rule intact for threshold tracking, action hashing, and Lua match_rules compatibility
- include the rustfmt-only mod-counter-series hunk required by the current nightly formatter check

Fixes #350.

## Notes
This avoids the extra regex-list scan from the earlier sketch in the issue thread. Rule matching still performs a single pass over each rule's regex list; the matched regex is retained as display metadata alongside the full Rule.

## Tests
- cargo test -p kumo-api-types --lib
- cargo test -p tsa-daemon
- cargo test -p mod-counter-series
- cargo +nightly fmt --all -- --check
- git diff --check

## Not tested
- cargo test -p kumo-api-types, because the crate's doctest pass currently fails on an existing BounceV1Request documentation snippet that is unrelated to this change.