### PR TITLE
bugfix: invalid control characters in Authentication-Results

### DIFF
--- a/crates/dkim/src/arc.rs
+++ b/crates/dkim/src/arc.rs
@@ -583,4 +583,63 @@ mod test {
             email_content = sealed;
         }
     }
+
+    /// Microsoft 365 / Outlook sends ARC-Authentication-Results headers with
+    /// non-standard syntax (e.g. bare `action=none` without a `ptype.`
+    /// prefix).  The nom parser consumes what it understands and then
+    /// `all_consuming` produces an `Eof` error for the leftover input.
+    /// `explain_nom` formats that error as a multi-line diagnostic string
+    /// containing `\n`.  That string ends up in `ARCIssue::reason` and, from
+    /// there, in the `reason=` field of the emitted `Authentication-Results`
+    /// header — producing an invalid folded header value.
+    ///
+    /// This test traces the exact code path so that the right fix location is
+    /// visible: the newlines enter at the `format!("...{err:#}")` call in
+    /// `ARC::verify` (crates/dkim/src/arc.rs), not inside `emit_value_token`.
+    #[tokio::test]
+    async fn arc_verify_malformed_aar_reason_has_no_control_chars() {
+        // Construct a minimal message containing only a malformed
+        // ARC-Authentication-Results header.  The `action=none` token after
+        // `dmarc=pass` is not valid authres syntax (it needs a `ptype.`
+        // prefix), so the parser stops there and `all_consuming` reports an
+        // `Eof` error whose verbose rendering contains newlines.
+        let message = concat!(
+            "ARC-Authentication-Results: i=1; example.com;\r\n",
+            "\tdmarc=pass action=none header.from=example.com\r\n",
+            "\r\n",
+            "Body\r\n",
+        );
+
+        let email = ParsedEmail::parse(message).unwrap();
+        let resolver = TestResolver::default();
+        let arc = ARC::verify(&email, &resolver).await;
+
+        // The verification must fail (the ARC-Authentication-Results header is malformed).
+        assert_eq!(arc.chain_validation_status(), ChainValidationStatus::Fail);
+
+        // The reason string produced from the nom error contains newlines.
+        let reason = &arc.issues[0].reason;
+        assert!(
+            reason.contains('\n'),
+            "expected nom diagnostic newlines in reason, got: {reason:?}"
+        );
+
+        // When this reason is placed into an Authentication-Results header it
+        // must not contain raw control characters. Those would make the
+        // header invalid per RFC 5322.
+        let ar = mailparsing::AuthenticationResults {
+            serv_id: "mx.example.com".into(),
+            version: None,
+            results: vec![arc.authentication_result()],
+        };
+        let encoded = mailparsing::EncodeHeaderValue::encode_value(&ar);
+        let has_ctl = encoded
+            .as_bytes()
+            .iter()
+            .any(|&b| matches!(b, 0..=8 | 10..=31 | 127));
+        assert!(
+            !has_ctl,
+            "encoded Authentication-Results header contains control characters:\n{encoded:?}"
+        );
+    }
 }

--- a/crates/mailparsing/src/rfc5322_parser.rs
+++ b/crates/mailparsing/src/rfc5322_parser.rs
@@ -1840,19 +1840,12 @@ pub struct AuthenticationResults {
     pub results: Vec<AuthenticationResult>,
 }
 
-/// Emits a value into target, quoting it if it contains characters outside
-/// the mime-token set. Control characters are stripped. They are not valid
-/// in RFC 5322 quoted-strings and can appear in ARC error reason strings
-/// produced by the multi-line diagnostic formatter.
 fn emit_value_token(value: &[u8], target: &mut Vec<u8>) {
     // Allow '@' bare since the pvalue parser handles @domain and local@domain
     let use_quoted_string = !value.iter().all(|&c| is_mime_token(c) || c == b'@');
     if use_quoted_string {
         target.push(b'"');
         for (start, end, c) in value.char_indices() {
-            if is_ctl(c as u8) {
-                continue;
-            }
             if c == '"' || c == '\\' {
                 target.push(b'\\');
             }

--- a/crates/mailparsing/src/rfc5322_parser.rs
+++ b/crates/mailparsing/src/rfc5322_parser.rs
@@ -1840,13 +1840,19 @@ pub struct AuthenticationResults {
     pub results: Vec<AuthenticationResult>,
 }
 
-/// Emits a value that was parsed by `value`, into target
+/// Emits a value into target, quoting it if it contains characters outside
+/// the mime-token set. Control characters are stripped. They are not valid
+/// in RFC 5322 quoted-strings and can appear in ARC error reason strings
+/// produced by the multi-line diagnostic formatter.
 fn emit_value_token(value: &[u8], target: &mut Vec<u8>) {
     // Allow '@' bare since the pvalue parser handles @domain and local@domain
     let use_quoted_string = !value.iter().all(|&c| is_mime_token(c) || c == b'@');
     if use_quoted_string {
         target.push(b'"');
         for (start, end, c) in value.char_indices() {
+            if is_ctl(c as u8) {
+                continue;
+            }
             if c == '"' || c == '\\' {
                 target.push(b'\\');
             }

--- a/crates/mailparsing/src/rfc5322_parser.rs
+++ b/crates/mailparsing/src/rfc5322_parser.rs
@@ -1840,6 +1840,7 @@ pub struct AuthenticationResults {
     pub results: Vec<AuthenticationResult>,
 }
 
+/// Emits a value that was parsed by `value`, into target
 fn emit_value_token(value: &[u8], target: &mut Vec<u8>) {
     // Allow '@' bare since the pvalue parser handles @domain and local@domain
     let use_quoted_string = !value.iter().all(|&c| is_mime_token(c) || c == b'@');


### PR DESCRIPTION
Microsoft 365 / Outlook tends to send malformed ARC headers. They lead to an error report from `mail_auth.check`. The function writes this report as a mail header:

```
...
arc=fail reason="An ARC-Authentication-Results header could not be parsed: invalid header: Error at line 2, in Eof: smtp.mailfrom=example.com; dmarc=pass action=none header.from=example.com; dkim=pass ^______________________________________________________________________"
```

Before this bugfix, the `reason` string contained control characters including `\n` from the error formatting. This led to a malformed header. Software like Stalwart bounces the mail.

The already existing function `is_ctl` is RFC conform and filters invalid characters before adding them to the header.