### PR TITLE
Add uninteresting_log_record_types option to setup_with_automation

### DIFF
--- a/assets/policy-extras/shaping.lua
+++ b/assets/policy-extras/shaping.lua
@@ -61,7 +61,7 @@ end
 -- purposes: these represent messages coming into the system,
 -- or movement through internal queues, rather than interactions
 -- with a destination system
-local UNINTERESTING_LOG_RECORD_TYPES = {
+local DEFAULT_UNINTERESTING_LOG_RECORD_TYPES = {
   AdminRebind = true,
   DeferredInjectionRebind = true,
   Delayed = true,
@@ -93,15 +93,8 @@ local function should_enq(publish, msg, hook_name, options)
     end
   end
 
-  if UNINTERESTING_LOG_RECORD_TYPES[log_record.type] then
+  if options.uninteresting_log_record_types[log_record.type] then
     return false
-  end
-
-  if options.custom_filter then
-    local status, result = pcall(options.custom_filter, log_record, hook_name)
-    if not status or not result then
-      return false
-    end
   end
 
   if options.pre_filter then
@@ -420,6 +413,11 @@ function mod:setup_with_automation(options)
     options.pre_filter = true
   end
 
+  if options.uninteresting_log_record_types == nil then
+    options.uninteresting_log_record_types =
+      DEFAULT_UNINTERESTING_LOG_RECORD_TYPES
+  end
+
   local cached_load_data = kumo.memoize(load_shaping_data, {
     name = 'shaping_data',
     ttl = options.cache_ttl or '1 minute',
@@ -473,7 +471,7 @@ function mod:setup_with_automation(options)
 
   local function setup_publish()
     local per_record = {}
-    for record_type, _true in pairs(UNINTERESTING_LOG_RECORD_TYPES) do
+    for record_type, _true in pairs(options.uninteresting_log_record_types) do
       per_record[record_type] = {
         enable = false,
       }

--- a/assets/policy-extras/shaping.lua
+++ b/assets/policy-extras/shaping.lua
@@ -98,7 +98,7 @@ local function should_enq(publish, msg, hook_name, options)
   end
 
   if options.custom_filter then
-    local status, result = pcall(options.custom_filter, log_record)
+    local status, result = pcall(options.custom_filter, log_record, hook_name)
     if not status or not result then
       return false
     end

--- a/assets/policy-extras/shaping.lua
+++ b/assets/policy-extras/shaping.lua
@@ -97,6 +97,13 @@ local function should_enq(publish, msg, hook_name, options)
     return false
   end
 
+  if options.custom_filter then
+    local status, result = pcall(options.custom_filter, log_record)
+    if not status or not result then
+      return false
+    end
+  end
+
   if options.pre_filter then
     -- Only bother shipping the log record over if it matches
     -- a TSA rule, so that we can avoid increasing IO pressure

--- a/docs/changelog/main.md
+++ b/docs/changelog/main.md
@@ -4,6 +4,13 @@
 
 ## Other Changes and Enhancements
 
+ * The `shaping.lua` helper's `setup_with_automation` now accepts an optional
+   `custom_filter` function. When set, it is called in the
+   `should_enqueue_log_record` hook **before** the built-in regex-based
+   `pre_filter` step, allowing cheap user-defined checks to short-circuit the
+   more expensive rule-matching scan and reduce CPU usage on high-volume
+   deployments.
+
  * New [kumo.counter_series](../reference/kumo.counter_series/index.md)
    module exposing in-memory rolling counters backed by a fixed-size ring of
    time buckets. Useful for short-term, per-process bookkeeping of event

--- a/docs/changelog/main.md
+++ b/docs/changelog/main.md
@@ -4,6 +4,10 @@
 
 ## Other Changes and Enhancements
 
+ * The `shaping.lua` helper's `setup_with_automation` now accepts an optional
+   `uninteresting_log_record_types` table, allowing users to customise
+   which log record types are suppressed from TSA publishing.
+
 ## Fixes
 
  * [kumo.crypto.aws_sign_v4](../reference/kumo.crypto/aws_sign_v4.md) had

--- a/docs/changelog/main.md
+++ b/docs/changelog/main.md
@@ -4,13 +4,6 @@
 
 ## Other Changes and Enhancements
 
- * The `shaping.lua` helper's `setup_with_automation` now accepts an optional
-   `custom_filter` function. When set, it is called in the
-   `should_enqueue_log_record` hook **before** the built-in regex-based
-   `pre_filter` step, allowing cheap user-defined checks to short-circuit the
-   more expensive rule-matching scan and reduce CPU usage on high-volume
-   deployments.
-
  * New [kumo.counter_series](../reference/kumo.counter_series/index.md)
    module exposing in-memory rolling counters backed by a fixed-size ring of
    time buckets. Useful for short-term, per-process bookkeeping of event
@@ -40,6 +33,12 @@
    [naming convention](../reference/message/set_meta.md#naming-convention-for-user-defined-keys)
    for details. Existing meta names continue to work; the `x_` prefix is a
    recommendation, not a hard requirement.
+ * The `shaping.lua` helper's `setup_with_automation` now accepts an optional
+   `custom_filter` function. When set, it is called in the
+   `should_enqueue_log_record` hook **before** the built-in regex-based
+   `pre_filter` step, allowing cheap user-defined checks to short-circuit the
+   more expensive rule-matching scan and reduce CPU usage on high-volume
+   deployments.
 
 ## Fixes
 


### PR DESCRIPTION
## Summary

  Add an `uninteresting_log_record_types` option to `shaping.lua`'s `setup_with_automation`
  that lets callers declaratively control which log record types are suppressed from TSA
  publishing. Callers who don't pass the option get the existing built-in defaults.


  ## Usage

  ```lua
  local shaper = shaping:setup_with_automation {
    publish = { 'http://127.0.0.1:8008' },
    subscribe = { 'http://127.0.0.1:8008' },
    extra_files = { '/opt/kumomta/etc/policy/shaping.toml' },

    -- Filter out Delivery events from going to TSA daemon,
    uninteresting_log_record_types = {
      AdminRebind = true,
      DeferredInjectionRebind = true,
      Delayed = true,
      Reception = true,
      Rejection = true,
      XferIn = true,
      XferOut = true,
      Delivery = true
    }
  }