### PR TITLE
http injection: reject newlines in generated headers

### DIFF
--- a/crates/kumod/src/http_server/inject_v1.rs
+++ b/crates/kumod/src/http_server/inject_v1.rs
@@ -476,6 +476,14 @@ struct Compiled<'a> {
     attached: Vec<MimePart<'a>>,
 }
 
+fn validate_header_value(header_name: &str, value: &str) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        !value.as_bytes().contains(&b'\r') && !value.as_bytes().contains(&b'\n'),
+        "content.headers['{header_name}'] must not contain newline characters"
+    );
+    Ok(())
+}
+
 impl<'a> Compiled<'a> {
     pub fn expand_for_recip(
         &self,
@@ -557,6 +565,7 @@ impl<'a> Compiled<'a> {
                         need_to = false;
                     }
                     let expanded = self.env_and_templates.borrow_dependent()[id].render(&subst)?;
+                    validate_header_value(name, &expanded)?;
                     id += 1;
                     builder.push(mailparsing::Header::new_unstructured(
                         name.to_string(),
@@ -1621,6 +1630,50 @@ Some(
         );
 
         k9::assert_equal!(structure.attachments.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_generate_builder_rejects_newline_in_header_value() {
+        let mut request = InjectV1Request {
+            envelope_sender: "noreply@example.com".to_string(),
+            recipients: vec![Recipient {
+                email: "user@example.com".to_string(),
+                name: Some("James Smythe".to_string()),
+                substitutions: HashMap::new(),
+                metadata: HashMap::new(),
+            }],
+            substitutions: HashMap::new(),
+            content: Content::Builder {
+                text_body: Some("I am the plain text".to_string()),
+                amp_html_body: None,
+                html_body: None,
+                attachments: vec![],
+                subject: Some("hello\n\nHello there".to_string()),
+                from: None,
+                reply_to: None,
+                headers: Default::default(),
+            },
+            deferred_spool: true,
+            deferred_generation: false,
+            trace_headers: Default::default(),
+            template_dialect: Default::default(),
+        };
+
+        request.normalize().unwrap();
+        let compiled = request.compile().unwrap();
+        let err = compiled
+            .expand_for_recip(
+                &request.recipients[0],
+                &request.substitutions,
+                &request.content,
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("content.headers['Subject'] must not contain newline characters"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[tokio::test]

--- a/crates/kumod/src/http_server/inject_v1.rs
+++ b/crates/kumod/src/http_server/inject_v1.rs
@@ -476,14 +476,6 @@ struct Compiled<'a> {
     attached: Vec<MimePart<'a>>,
 }
 
-fn validate_header_value(header_name: &str, value: &str) -> anyhow::Result<()> {
-    anyhow::ensure!(
-        !value.as_bytes().contains(&b'\r') && !value.as_bytes().contains(&b'\n'),
-        "content.headers['{header_name}'] must not contain newline characters"
-    );
-    Ok(())
-}
-
 impl<'a> Compiled<'a> {
     pub fn expand_for_recip(
         &self,
@@ -565,7 +557,6 @@ impl<'a> Compiled<'a> {
                         need_to = false;
                     }
                     let expanded = self.env_and_templates.borrow_dependent()[id].render(&subst)?;
-                    validate_header_value(name, &expanded)?;
                     id += 1;
                     builder.push(mailparsing::Header::new_unstructured(
                         name.to_string(),
@@ -1633,7 +1624,10 @@ Some(
     }
 
     #[tokio::test]
-    async fn test_generate_builder_rejects_newline_in_header_value() {
+    async fn test_generate_builder_subject_newline_cannot_inject_header() {
+        // Regression for #296: a newline in the subject must not be able to
+        // split the header block and inject an extra header. new_unstructured
+        // folds the value, so the injected line is collapsed into the subject.
         let mut request = InjectV1Request {
             envelope_sender: "noreply@example.com".to_string(),
             recipients: vec![Recipient {
@@ -1648,7 +1642,7 @@ Some(
                 amp_html_body: None,
                 html_body: None,
                 attachments: vec![],
-                subject: Some("hello\n\nHello there".to_string()),
+                subject: Some("hello\nInjected: evil".to_string()),
                 from: None,
                 reply_to: None,
                 headers: Default::default(),
@@ -1661,18 +1655,21 @@ Some(
 
         request.normalize().unwrap();
         let compiled = request.compile().unwrap();
-        let err = compiled
+        let generated = compiled
             .expand_for_recip(
                 &request.recipients[0],
                 &request.substitutions,
                 &request.content,
             )
-            .unwrap_err();
+            .unwrap();
 
         assert!(
-            err.to_string()
-                .contains("content.headers['Subject'] must not contain newline characters"),
-            "unexpected error: {err:#}"
+            generated.contains("Subject: hello Injected: evil"),
+            "subject should be folded onto a single logical line: {generated}"
+        );
+        assert!(
+            !generated.contains("\nInjected: evil"),
+            "newline must not introduce a new header: {generated}"
         );
     }
 

--- a/crates/mailparsing/src/header.rs
+++ b/crates/mailparsing/src/header.rs
@@ -708,6 +708,30 @@ Subject: =?UTF-8?q?hello_there_Andr=C3=A9,_this_is_a_longer_header_than_the_sta?
     }
 
     #[test]
+    fn test_unstructured_newline_cannot_inject_header() {
+        // Regression for kumomta#296: a newline in an unstructured value must
+        // not be able to escape the value and inject a new header line, both
+        // for ascii (folded) and non-ascii (qp-encoded) inputs.
+        let header = Header::new_unstructured("Subject", "hello\nInjected: evil");
+        k9::assert_equal!(
+            header.to_header_string(),
+            "Subject: hello Injected: evil\r\n"
+        );
+        assert!(!header.value.as_bytes().contains(&b'\n'));
+        assert!(!header.value.as_bytes().contains(&b'\r'));
+
+        let header = Header::new_unstructured("Subject", "héllo\nInjected: evil");
+        assert!(!header.value.as_bytes().contains(&b'\n'));
+        assert!(!header.value.as_bytes().contains(&b'\r'));
+
+        let header = Header::new_unstructured("Subject", "hello\r\nInjected: evil");
+        k9::assert_equal!(
+            header.to_header_string(),
+            "Subject: hello Injected: evil\r\n"
+        );
+    }
+
+    #[test]
     fn test_unstructured_encode_farsi() {
         let farsi_input = "بوت‌كمپ قدرت نوشتن رهنماکالج";
         let header = Header::new_unstructured("Subject", farsi_input);


### PR DESCRIPTION
Fixes #296.

A newline in the subject or a custom header passed to the HTTP injection builder must not be able to split the header block and inject an extra header.

It turns out `mailparsing::Header::new_unstructured` already neutralizes this: `wrap_bytes` folds ASCII values (collapsing the whitespace run) and `qp_encode` escapes non-ASCII ones, so the value cannot escape. This PR relies on that existing behavior instead of a separate check in the inject builder:

- Drop the redundant validation in `inject_v1`.
- Lock the guarantee with a regression test at the `new_unstructured` layer, covering ASCII, non-ASCII and CRLF inputs (so Lua/Rust callers are covered too).
- Keep an inject-path regression test for #296.

Note: the fold collapses a multi-line value onto a single logical line. Preserving the author's line breaks as proper CFWS folds would be new behavior and can be a follow-up.

Test:

```
cargo test -p mailparsing test_unstructured_newline_cannot_inject_header
cargo test -p kumod test_generate_builder_subject_newline_cannot_inject_header
```
