### PR TITLE
fix(kumo-log-types): parse obsolete "UTC" timezone in RFC 3464/5965 dates (Amazon SES OOB bounces)

### DIFF
--- a/crates/kumo-log-types/data/rfc3464/obsolete_arrival_date.eml
+++ b/crates/kumo-log-types/data/rfc3464/obsolete_arrival_date.eml
@@ -1,0 +1,31 @@
+From: mailer-daemon@mx.example.com
+To: bounce@example.com
+Message-ID: <0100019f242fc810-60940dcf-462f-4e71-988f-2343410adfa5-000000@example.com>
+Subject: Delivery Status Notification (Failure)
+MIME-Version: 1.0
+Content-Type: multipart/report; 
+	boundary="----=_Part_693010_1985408142.1783018539024"; 
+	report-type=delivery-status
+
+------=_Part_693010_1985408142.1783018539024
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: 7bit
+Content-Description: Notification
+
+Mailbox does not exist
+------=_Part_693010_1985408142.1783018539024
+Content-Type: message/delivery-status
+Content-Transfer-Encoding: 7bit
+Content-Description: Delivery Status Notification
+
+Reporting-MTA: dns; mx.example.com
+Arrival-Date: Thu, 02 Jul 26 18:55:38 UTC
+
+Action: failed
+Final-Recipient: rfc822; user@example.com
+Original-Recipient: rfc822; user@example.com
+Diagnostic-Code: smtp; 550 5.1.1 Mailbox does not exist
+Status: 5.1.1
+
+
+------=_Part_693010_1985408142.1783018539024--

--- a/crates/kumo-log-types/src/rfc3464.rs
+++ b/crates/kumo-log-types/src/rfc3464.rs
@@ -670,6 +670,23 @@ mod test {
     use crate::ResolvedAddress;
     use rfc5321::{EnhancedStatusCode, Response};
 
+    #[test]
+    fn parse_ses_obsolete_arrival_date() {
+        // Amazon SES OOB bounces carry an Arrival-Date in an obsolete RFC 2822
+        // form ("Thu, 02 Jul 26 18:55:38 UTC"). This must not fail the report.
+        let report = Report::parse(include_bytes!("../data/rfc3464/obsolete_arrival_date.eml"))
+            .unwrap()
+            .expect("multipart/report DSN should parse as a report");
+        let arrival = report
+            .per_message
+            .arrival_date
+            .expect("obsolete Arrival-Date should be recovered, not dropped");
+        assert_eq!(arrival.to_rfc3339(), "2026-07-02T18:55:38+00:00");
+        assert_eq!(report.per_recipient.len(), 1);
+        assert_eq!(report.per_recipient[0].action, ReportAction::Failed);
+        assert_eq!(report.per_recipient[0].status.class, 5);
+    }
+
     fn make_message() -> MimePart<'static> {
         let mut part = MimePart::new_text_plain("hello there").unwrap();
         part.headers_mut().set_subject("Hello!").unwrap();

--- a/crates/kumo-log-types/src/rfc5965.rs
+++ b/crates/kumo-log-types/src/rfc5965.rs
@@ -201,7 +201,19 @@ pub(crate) struct DateTimeRfc2822(pub DateTime<Utc>);
 impl FromStr for DateTimeRfc2822 {
     type Err = anyhow::Error;
     fn from_str(input: &str) -> anyhow::Result<Self> {
-        let date = DateTime::parse_from_rfc2822(input)?;
+        let date = DateTime::parse_from_rfc2822(input).or_else(|err| {
+            // Amazon SES emits an obsolete date form that uses the alphabetic
+            // zone "UTC", which is not a valid RFC 2822 zone (RFC 2822 defines
+            // "UT" and "GMT", not "UTC"), so chrono rejects it. "UTC" is exactly
+            // +0000, so normalize the zone and retry before giving up.
+            match input
+                .strip_suffix(" UTC")
+                .or_else(|| input.strip_suffix(" utc"))
+            {
+                Some(prefix) => DateTime::parse_from_rfc2822(&format!("{prefix} +0000")),
+                None => Err(err),
+            }
+        })?;
         Ok(Self(date.into()))
     }
 }
@@ -308,6 +320,26 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn datetime_rfc2822_obsolete_utc_zone() {
+        // Amazon SES emits dates with the non-standard alphabetic zone "UTC".
+        let parsed: DateTime<Utc> = "Thu, 02 Jul 26 18:55:38 UTC"
+            .parse::<DateTimeRfc2822>()
+            .expect("SES obsolete UTC zone should parse")
+            .into();
+        assert_eq!(parsed.to_rfc3339(), "2026-07-02T18:55:38+00:00");
+
+        // Standard forms keep working.
+        let canonical: DateTime<Utc> = "Thu, 02 Jul 2026 18:55:38 +0000"
+            .parse::<DateTimeRfc2822>()
+            .unwrap()
+            .into();
+        assert_eq!(parsed, canonical);
+
+        // A genuinely unparseable value still errors.
+        assert!("not a date".parse::<DateTimeRfc2822>().is_err());
+    }
 
     #[test]
     fn rfc5965_1() {


### PR DESCRIPTION
## Summary

`DateTimeRfc2822::from_str` (in `kumo-log-types`) uses `chrono::DateTime::parse_from_rfc2822`, which rejects the alphabetic timezone token `UTC`. Amazon SES emits its DSN `Arrival-Date` in exactly that form, e.g.:

```
Arrival-Date: Thu, 02 Jul 26 18:55:38 UTC
```

Because `parse_from_rfc2822` errors on `UTC`, and `rfc3464`'s per-message `Arrival-Date` is parsed with the error-propagating `extract_single_conv`, the whole `Report::parse` fails. In practice this means KumoMTA silently drops otherwise-valid out-of-band (OOB) bounce DSNs generated by SES: `log_oob` never classifies them, so no bounce record is produced.

This PR makes `DateTimeRfc2822` recover the timestamp by normalizing the non-standard `UTC` zone to `+0000` before giving up.

## Root cause

SES's date is, strictly speaking, non-conformant. RFC 3464 section 2.2.5 (Arrival-Date), repeated in 2.3.7 (Last-Attempt-Date) and 2.3.9 (Will-Retry-Until), says:

> "The date and time are expressed in RFC 822 'date-time' format, as modified by [HOSTREQ]. Numeric timezones ([+/-]HHMM format) MUST be used."

So `UTC` (alphabetic) violates a MUST; the conformant zero-offset token is `+0000`. chrono is therefore technically correct to reject it.

The problem is that chrono is the *only* widely-used parser that turns this common quirk into a hard error, and KumoMTA inherits that strictness in the OOB parsing path, where a single non-conformant date field discards an entire otherwise-valid bounce.

## Reproduction

```rust
use chrono::DateTime;
// what Amazon SES actually sends:
assert!(DateTime::parse_from_rfc2822("Thu, 02 Jul 26 18:55:38 UTC").is_err());
// same instant, conformant zone: parses fine
assert!(DateTime::parse_from_rfc2822("Thu, 02 Jul 26 18:55:38 +0000").is_ok());
assert!(DateTime::parse_from_rfc2822("Thu, 02 Jul 26 18:55:38 GMT").is_ok());
```

The 2-digit year (`26`) is fine; only the `UTC` zone token trips it up.

## Every other parser tolerates it

The exact SES string `Thu, 02 Jul 26 18:55:38 UTC`, run through a range of implementations:

| Implementation | What it is | Accepts `UTC`? |
| --- | --- | --- |
| Stalwart `mail-parser` | Rust OSS mail server | yes -> +0000 |
| Dovecot | C IMAP/mail server | yes -> +0000 |
| Go `net/mail` | Go standard library | yes -> +0000 |
| Python `email.utils` | Python standard library | yes -> +0000 |
| Ruby `Time.rfc2822` | Ruby standard library | yes -> +0000 |
| GNU coreutils `date` | ubiquitous C date parser | yes -> +0000 |
| Nodemailer `mailparser` | Node mail ecosystem | yes -> +0000 |
| Sisimai | purpose-built bounce/DSN parser with SES support | yes -> -0000 (same instant) |
| chrono `parse_from_rfc2822` | KumoMTA today | **no (hard error)** |

Stalwart's `mail-parser` is another Rust implementation and recovers the same instant this PR produces. Dovecot is a good illustration of the general pattern: it doesn't even special-case `UTC`; it degrades any unrecognized zone to GMT, with a source comment that captures the rationale exactly:

> `/* timezone. invalid timezones are treated as GMT, because we may not know all the possible timezones that are used and it's better to give at least a mostly correct reply. */`

(Relay-only MTAs such as Postfix, Exim, and Sendmail are intentionally omitted: they generate and route bounces but do not parse `message/delivery-status` date fields, so there is no equivalent code path to compare.)

## The fix

In `DateTimeRfc2822::from_str`, if the strict parse fails, retry once with a trailing `UTC` normalized to `+0000`, then fall through to the original error for anything genuinely unparseable:

```rust
let date = DateTime::parse_from_rfc2822(input).or_else(|err| {
    match input
        .strip_suffix(" UTC")
        .or_else(|| input.strip_suffix(" utc"))
    {
        Some(prefix) => DateTime::parse_from_rfc2822(&format!("{prefix} +0000")),
        None => Err(err),
    }
})?;
```

This is deliberately narrow: it touches only the one non-standard token real senders emit, keeps all existing behavior for valid input, and still errors on genuinely bad values.

## Alternative: default any unrecognized zone to +0000

Most of the parsers above go further than this PR: they treat *any* unrecognized alphabetic zone as `+0000` rather than failing. Stalwart's `mail-parser` (also Rust) is the clearest example; its `obs_zone` matches only the North American DST abbreviations and funnels everything else, including `UTC` and `GMT`, through `.unwrap_or(0)`:

```rust
hashify::tiny_map! { buf.as_ref(),
    "EDT" => -4, "EST" => -5, "CDT" => -5, "CST" => -6,
    "MDT" => -6, "MST" => -7, "PDT" => -7, "PST" => -8,
}
.unwrap_or(0)
```

Dovecot does the same, with a comment: "invalid timezones are treated as GMT, because we may not know all the possible timezones that are used and it's better to give at least a mostly correct reply."

I chose the narrower `UTC`-only normalization deliberately:

- chrono already parses every legitimate RFC 822 obs-zone (`GMT`, `UT`, `EST`/`EDT`, ...) with its correct offset, so the only common token it rejects that real senders emit is `UTC`.
- `UTC` is exactly `+0000`, so normalizing it is lossless.
- Defaulting *all* unknown alphabetic zones to `+0000` is knowingly lossy: a real-offset named zone such as `JST` would silently parse as `+0000` instead of `+0900`. Failing on those seems safer than inventing a wrong timestamp.

If you would prefer the broader-leniency approach the other parsers take, I am happy to switch `DateTimeRfc2822` to fall back to `+0000` for any unrecognized zone instead. Just let me know which you would rather have.

## Tests

- `rfc5965::test::datetime_rfc2822_obsolete_utc_zone` - unit test on `DateTimeRfc2822`: the SES form parses to the same instant as the canonical `+0000` form, and a junk string still errors.
- `rfc3464::test::parse_ses_obsolete_arrival_date` - end-to-end: a `multipart/report` DSN with the obsolete `Arrival-Date` parses successfully and the timestamp is recovered (not dropped), with `Action: failed` and status class 5.
- New fixture `crates/kumo-log-types/data/rfc3464/obsolete_arrival_date.eml`, derived from a real SES OOB bounce and sanitized to `example.com`.

`cargo test -p kumo-log-types` passes (19 tests); `cargo fmt` clean.
