### PR TITLE
add check_trailing_bits: false

### DIFF
--- a/crates/mailparsing/src/mimepart.rs
+++ b/crates/mailparsing/src/mimepart.rs
@@ -23,6 +23,7 @@ const BASE64_RFC2045: data_encoding::Encoding = data_encoding_macro::new_encodin
     ignore: " \r\n\t",
     wrap_width: 76,
     wrap_separator: "\r\n",
+    check_trailing_bits: false,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2281,5 +2282,16 @@ Body\r
                 attachments: vec![image_part.clone()],
             }
         );
+    }
+
+    /// Test the use case of check_trailing_bits being false
+    /// This allows trailing garbage to be ignored, otherwise strict base64 decoder would return a failure
+    /// For reference, valid base64 is aHRtbD4NCg==
+    #[test]
+    fn check_trailing_bits_test() {
+        // The low 4 trailing bits before `==` are non-zero in this sample.
+        // With check_trailing_bits=false we should still accept and decode it.
+        let decoded = BASE64_RFC2045.decode(b"aHRtbD4NCi==").unwrap();
+        assert_eq!(decoded, b"html>\r\n");
     }
 }


### PR DESCRIPTION
Adding check_trailing_bits: false into base64 decoder.

While testing message parsing code, there's rare chance sender isn't fully compliant with base64.
This leads to failure such as below

```base64 decode: non-zero trailing bits at 20211 b='i' in HRtbD4NCi==```

As long as it's not destructive, its more convenient to be able to support non-RFC messages so we can extract message artifacts for it's decision making.