### PR TITLE
rfc5321: tolerate stray space after MAIL FROM:/RCPT TO: colon

### DIFF
--- a/crates/rfc5321/src/parser.rs
+++ b/crates/rfc5321/src/parser.rs
@@ -1820,10 +1820,14 @@ fn parse_mail_from(input: Span) -> IResult<Span, MaybePartialCommand> {
                     tag_no_case("MAIL"),
                     wsp,
                     tag_no_case("FROM:"),
+                    // RFC 5321 has no space between the colon and the reverse-path,
+                    // but many legacy clients emit one (`MAIL FROM: <addr>`). Tolerate
+                    // and discard it rather than rejecting with 501 5.1.7.
+                    opt(wsp),
                     reverse_path,
                     opt(map((wsp, mail_parameters), |(_, p)| p)),
                 )),
-                |(_, _, _, address, parameters)| {
+                |(_, _, _, _, address, parameters)| {
                     MaybePartialCommand::Full(Command::MailFrom {
                         address,
                         parameters: parameters.unwrap_or_default(),
@@ -1836,11 +1840,12 @@ fn parse_mail_from(input: Span) -> IResult<Span, MaybePartialCommand> {
                     tag_no_case("MAIL"),
                     wsp,
                     tag_no_case("FROM:"),
+                    opt(wsp),
                     reverse_path,
                     wsp,
                     anything,
                 )),
-                |(_, _, _, _, _, remainder)| MaybePartialCommand::Partial {
+                |(_, _, _, _, _, _, remainder)| MaybePartialCommand::Partial {
                     verb: CommandVerb::Mail,
                     remainder: (*remainder).into(),
                     reason: PartialReason::Syntax,
@@ -1896,10 +1901,13 @@ fn parse_rcpt_to(input: Span) -> IResult<Span, MaybePartialCommand> {
                     tag_no_case("RCPT"),
                     wsp,
                     tag_no_case("TO:"),
+                    // Tolerate a stray space after the colon (`RCPT TO: <addr>`),
+                    // as emitted by some legacy clients; see MAIL FROM above.
+                    opt(wsp),
                     forward_path,
                     opt(map((wsp, mail_parameters), |(_, p)| p)),
                 )),
-                |(_, _, _, address, parameters)| {
+                |(_, _, _, _, address, parameters)| {
                     MaybePartialCommand::Full(Command::RcptTo {
                         address,
                         parameters: parameters.unwrap_or_default(),
@@ -1912,11 +1920,12 @@ fn parse_rcpt_to(input: Span) -> IResult<Span, MaybePartialCommand> {
                     tag_no_case("RCPT"),
                     wsp,
                     tag_no_case("TO:"),
+                    opt(wsp),
                     forward_path,
                     wsp,
                     anything,
                 )),
-                |(_, _, _, _, _, remainder)| MaybePartialCommand::Partial {
+                |(_, _, _, _, _, _, remainder)| MaybePartialCommand::Partial {
                     verb: CommandVerb::Rcpt,
                     remainder: (*remainder).into(),
                     reason: PartialReason::Syntax,
@@ -2650,6 +2659,47 @@ Ok(
     }
 
     #[test]
+    fn test_mail_from_space_before_path() {
+        // RFC 5321 forbids a space between the colon and the reverse-path, but
+        // some legacy clients emit one. We tolerate and discard it rather than
+        // rejecting with 501 5.1.7.
+        for cmd in [
+            "MAIL FROM: <user@host>",
+            "MAIL FROM:\t<user@host>",
+            "MAIL FROM:   <user@host>",
+        ] {
+            k9::assert_equal!(
+                unwrapper(Command::parse(cmd)),
+                MaybePartialCommand::Full(Command::MailFrom {
+                    address: mail_path("user", Domain::DomainName("host".parse().unwrap())),
+                    parameters: vec![],
+                })
+            );
+        }
+
+        // Null sender with a stray space.
+        k9::assert_equal!(
+            unwrapper(Command::parse("MAIL FROM: <>")),
+            MaybePartialCommand::Full(Command::MailFrom {
+                address: ReversePath::NullSender,
+                parameters: vec![],
+            })
+        );
+
+        // ESMTP parameters still parse after the relaxed leading space.
+        k9::assert_equal!(
+            unwrapper(Command::parse("MAIL FROM: <user@host> BODY=8BITMIME")),
+            MaybePartialCommand::Full(Command::MailFrom {
+                address: mail_path("user", Domain::DomainName("host".parse().unwrap())),
+                parameters: vec![EsmtpParameter {
+                    name: "BODY".into(),
+                    value: Some("8BITMIME".into()),
+                }],
+            })
+        );
+    }
+
+    #[test]
     fn test_mail_from_at_domain_list() {
         k9::assert_equal!(
             unwrapper(Command::parse(
@@ -2837,6 +2887,46 @@ Ok(
             MaybePartialCommand::Full(Command::RcptTo {
                 address: rcpt_path("user", Domain::DomainName("host".parse().unwrap())),
                 parameters: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn test_rcpt_to_space_before_path() {
+        // Tolerate a stray space after the colon (`RCPT TO: <addr>`), as emitted
+        // by some legacy clients.
+        for cmd in [
+            "RCPT TO: <user@host>",
+            "RCPT TO:\t<user@host>",
+            "RCPT TO:   <user@host>",
+        ] {
+            k9::assert_equal!(
+                unwrapper(Command::parse(cmd)),
+                MaybePartialCommand::Full(Command::RcptTo {
+                    address: rcpt_path("user", Domain::DomainName("host".parse().unwrap())),
+                    parameters: vec![],
+                })
+            );
+        }
+
+        // Postmaster with a stray space.
+        k9::assert_equal!(
+            unwrapper(Command::parse("RCPT TO: <Postmaster>")),
+            MaybePartialCommand::Full(Command::RcptTo {
+                address: ForwardPath::Postmaster,
+                parameters: vec![],
+            })
+        );
+
+        // ESMTP parameters still parse after the relaxed leading space.
+        k9::assert_equal!(
+            unwrapper(Command::parse("RCPT TO: <user@host> NOTIFY=SUCCESS")),
+            MaybePartialCommand::Full(Command::RcptTo {
+                address: rcpt_path("user", Domain::DomainName("host".parse().unwrap())),
+                parameters: vec![EsmtpParameter {
+                    name: "NOTIFY".into(),
+                    value: Some("SUCCESS".into()),
+                }],
             })
         );
     }

--- a/docs/changelog/main.md
+++ b/docs/changelog/main.md
@@ -39,6 +39,12 @@
 
 ## Other Changes and Enhancements
 
+ * The ESMTP command parser now tolerates a stray space between the colon and
+   the address in `MAIL FROM:` and `RCPT TO:` commands (e.g. `MAIL FROM: <a@b>`).
+   RFC 5321 does not permit this space, but a number of legacy clients emit it;
+   previously such commands were rejected with `501 5.1.7`. The space is
+   discarded and the address parsed as normal.
+
  * [enable_dane](../reference/kumo/make_egress_path/enable_dane.md) can now be
    used with the Hickory resolver (with DNSSEC validation enabled); it no
    longer requires the unbound resolver.


### PR DESCRIPTION
## Summary

Some legacy SMTP clients emit a stray space between the colon and the address
in `MAIL FROM:` / `RCPT TO:` commands (e.g. `MAIL FROM: <addr>`). RFC 5321 does
not allow this space, so `kumod` rejects these commands with `501 5.1.7 Bad
sender's mailbox address syntax`.

Per review feedback, this relaxes the `rfc5321` grammar directly rather than
adding an opt-in listener option: the parser now accepts and discards an
optional run of spaces/tabs after the colon in both `MAIL FROM:` and
`RCPT TO:`. This is applied to both the success arm and the
"valid-address + trailing junk" arm so the resulting `Syntax` /
`InvalidSenderAddress` classification stays correct.

The previous approach (`allow_space_before_path` listener option + helper +
reference doc) has been dropped; `smtp_server.rs` is unchanged from `main`.

## Changes

- `crates/rfc5321/src/parser.rs`: allow optional `wsp` after the `FROM:`/`TO:`
  colon in `parse_mail_from` and `parse_rcpt_to`.
- Added `test_mail_from_space_before_path` and `test_rcpt_to_space_before_path`
  covering single/tab/multi-space, null sender, `<Postmaster>`, and ESMTP
  parameter cases.
- Changelog entry under "Other Changes and Enhancements".

## Test plan

- [x] `cargo test -p rfc5321 --lib parser::` — 165 passed, 0 failed (includes
  the two new tests, no regressions).
