### PR TITLE
add dmarc attributes

### DIFF
--- a/crates/kumo-dmarc/src/tests.rs
+++ b/crates/kumo-dmarc/src/tests.rs
@@ -540,6 +540,84 @@ async fn dmarc_pct_rate() {
     k9::assert_greater_than!(total_failures, lower_bound);
 }
 
+#[tokio::test]
+async fn dmarc_props_included_on_pass() {
+    let resolver = TestResolver::default()
+        .with_zone(EXAMPLE_COM)
+        .unwrap()
+        .with_txt(
+            "_dmarc.example.com",
+            "v=DMARC1; p=none; aspf=r; adkim=r; pct=100; \
+            rua=mailto:dmarc-feedback@example.com"
+                .to_string(),
+        );
+
+    let result = evaluate_ip(TestData {
+        from_domain: "example.com",
+        mail_from_domain: "example.com",
+        dkim_domains: &[],
+        resolver: &resolver,
+    })
+    .await;
+
+    // Verify domain doesn't include _dmarc prefix
+    assert_eq!(
+        result.props.get("dmarc.domain"),
+        Some(&"example.com".into()),
+        "dmarc.domain should be base domain without _dmarc prefix"
+    );
+
+    // Verify alignment results are present (SPF should pass, DKIM pass because no DKIM to fail)
+    assert_eq!(
+        result.props.get("dmarc.spf-alignment-result"),
+        Some(&"pass".into())
+    );
+
+    // Verify SPF domain is present for pass
+    assert_eq!(
+        result.props.get("dmarc.spf-domain"),
+        Some(&"example.com".into())
+    );
+}
+
+#[tokio::test]
+async fn dmarc_props_included_on_fail() {
+    let resolver = TestResolver::default()
+        .with_zone(EXAMPLE_COM)
+        .unwrap()
+        .with_txt(
+            "_dmarc.example.com",
+            "v=DMARC1; p=reject; aspf=s; adkim=s; \
+            rua=mailto:dmarc-feedback@example.com"
+                .to_string(),
+        );
+
+    let result = evaluate_ip(TestData {
+        from_domain: "example.com",
+        mail_from_domain: "otherdomain.com",
+        dkim_domains: &[Some("otherdomain.com")],
+        resolver: &resolver,
+    })
+    .await;
+
+    // Verify domain doesn't include _dmarc prefix
+    assert_eq!(
+        result.props.get("dmarc.domain"),
+        Some(&"example.com".into()),
+        "dmarc.domain should be base domain without _dmarc prefix"
+    );
+
+    // Verify alignment results show failure
+    assert_eq!(
+        result.props.get("dmarc.dkim-alignment-result"),
+        Some(&"fail".into())
+    );
+    assert_eq!(
+        result.props.get("dmarc.spf-alignment-result"),
+        Some(&"fail".into())
+    );
+}
+
 async fn evaluate_ip<'a>(
     TestData {
         from_domain,

--- a/crates/kumo-dmarc/src/types/record.rs
+++ b/crates/kumo-dmarc/src/types/record.rs
@@ -36,12 +36,19 @@ impl Record {
         cx.spf_aligned = super::results::DmarcResult::Fail;
         let mut dkim_errors = Vec::new();
         let mut spf_errors = Vec::new();
+        let mut dkim_signing_domain: Option<String> = None;
+        let mut spf_domain: Option<String> = None;
+
+        // Initialize props with dynamic information
+        let mut props = BTreeMap::new();
+        let base_domain = dmarc_domain.strip_prefix("_dmarc.").unwrap_or(dmarc_domain);
+        props.insert("dmarc.domain".into(), base_domain.into());
 
         if rand::random::<u8>() % 100 >= self.rate {
             return DispositionWithContext {
                 result: Disposition::Pass,
                 context: format!("sampled_out due to pct={}", self.rate),
-                props: BTreeMap::new(),
+                props,
             };
         }
 
@@ -54,6 +61,7 @@ impl Record {
 
                     if let Some(dkim_domain) = dkim.props.get("header.d") {
                         if let Ok(dkim_domain_str) = dkim_domain.to_str() {
+                            dkim_signing_domain = Some(dkim_domain_str.to_string());
                             if is_relaxed_aligned(cx.from_domain, dkim_domain_str) {
                                 dkim_errors.clear();
                                 cx.dkim_aligned = super::results::DmarcResult::Pass;
@@ -75,6 +83,7 @@ impl Record {
 
                     if let Some(dkim_domain) = dkim.props.get("header.d") {
                         if let Ok(dkim_domain_str) = dkim_domain.to_str() {
+                            dkim_signing_domain = Some(dkim_domain_str.to_string());
                             if is_strict_aligned(cx.from_domain, dkim_domain_str) {
                                 dkim_errors.clear();
                                 cx.dkim_aligned = super::results::DmarcResult::Pass;
@@ -90,12 +99,19 @@ impl Record {
             }
         }
 
+        // Add DKIM signing domain to props if available
+        if let Some(signing_domain) = dkim_signing_domain {
+            props.insert("dmarc.dkim-signing-domain".into(), signing_domain.into());
+        }
+
         if auth_result_is_pass(&cx.spf_result) {
-            let spf_domain = spf_alignment_domain(&cx.spf_result.props).or(cx.mail_from_domain);
+            spf_domain = spf_alignment_domain(&cx.spf_result.props)
+                .or(cx.mail_from_domain)
+                .map(|s| s.to_string());
 
             match self.align_spf {
                 Mode::Relaxed => {
-                    if let Some(mail_from_domain) = spf_domain {
+                    if let Some(mail_from_domain) = &spf_domain {
                         if is_relaxed_aligned(cx.from_domain, mail_from_domain) {
                             cx.spf_aligned = super::results::DmarcResult::Pass;
                         } else {
@@ -105,7 +121,7 @@ impl Record {
                     }
                 }
                 Mode::Strict => {
-                    if let Some(mail_from_domain) = spf_domain {
+                    if let Some(mail_from_domain) = &spf_domain {
                         if !is_strict_aligned(cx.from_domain, mail_from_domain) {
                             cx.spf_aligned = super::results::DmarcResult::Fail;
                             spf_errors.push("DMARC: SPF strict check failed".to_string());
@@ -117,13 +133,28 @@ impl Record {
             }
         }
 
+        // Add SPF domain to props if available
+        if let Some(spf_domain_val) = spf_domain {
+            props.insert("dmarc.spf-domain".into(), spf_domain_val.into());
+        }
+
+        // Add alignment results to props
+        props.insert(
+            "dmarc.dkim-alignment-result".into(),
+            format!("{:?}", cx.dkim_aligned).to_lowercase().into(),
+        );
+        props.insert(
+            "dmarc.spf-alignment-result".into(),
+            format!("{:?}", cx.spf_aligned).to_lowercase().into(),
+        );
+
         if cx.dkim_aligned == super::results::DmarcResult::Pass
             || cx.spf_aligned == super::results::DmarcResult::Pass
         {
             return DispositionWithContext {
                 result: Disposition::Pass,
                 context: "Success".into(),
-                props: BTreeMap::new(),
+                props,
             };
         }
 
@@ -144,14 +175,14 @@ impl Record {
             return DispositionWithContext {
                 result,
                 context: alignment_context,
-                props: BTreeMap::new(),
+                props,
             };
         }
 
         DispositionWithContext {
             result: self.disposition(sender_domain_alignment),
             context: "No aligned DKIM or SPF".into(),
-            props: BTreeMap::new(),
+            props,
         }
     }
 


### PR DESCRIPTION
Add dmarc attributes helpful for debugging. 

New props would look like below.
Those prefixed with "dmarc" are mostly what are derived through the execution of dmarc and it's analysis result.

```
  "dmarc": {
    "method": "dmarc",
    "props": {
      "dmarc.dkim-alignment-result": "pass",
      "dmarc.dkim-signing-domain": "gmail.com",
      "dmarc.domain": "gmail.com",
      "dmarc.spf-alignment-result": "pass",
      "dmarc.spf-domain": "gmail.com",
      "policy.p": "none",
      "policy.rua": "mailto:mailauth-reports@google.com",
      "policy.sp": "quarantine"
    },
    "reason": "Success",
    "result": "pass"
  },

```