### PR TITLE
message: persist envelope changes to the meta spool

### DIFF
--- a/crates/message/src/message.rs
+++ b/crates/message/src/message.rs
@@ -741,7 +741,13 @@ impl Message {
         match &mut inner.metadata {
             Some(meta) => {
                 meta.sender = sender;
-                inner.flags.set(MessageFlags::DATA_DIRTY, true);
+                // The sender lives in the metadata, so mark META_DIRTY.
+                // Marking DATA_DIRTY here is incorrect: it fails to persist
+                // the new sender to the meta spool, and if the message data
+                // has already been saved and shrunk (empty in-memory buffer)
+                // it makes a subsequent save fail with "message data must not
+                // be empty".
+                inner.flags.set(MessageFlags::META_DIRTY, true);
                 Ok(())
             }
             None => anyhow::bail!("Message::set_sender: metadata is not loaded"),
@@ -795,7 +801,13 @@ impl Message {
         match &mut inner.metadata {
             Some(meta) => {
                 meta.recipient = recipient;
-                inner.flags.set(MessageFlags::DATA_DIRTY, true);
+                // The recipient list lives in the metadata, so mark
+                // META_DIRTY. Marking DATA_DIRTY here is incorrect: it fails
+                // to persist the new recipients to the meta spool, and if the
+                // message data has already been saved and shrunk (empty
+                // in-memory buffer) it makes a subsequent save fail with
+                // "message data must not be empty".
+                inner.flags.set(MessageFlags::META_DIRTY, true);
                 Ok(())
             }
             None => anyhow::bail!("Message::set_recipient_list: metadata is not loaded"),
@@ -2106,6 +2118,88 @@ pub(crate) mod test {
         lua.load("assert(msg:get_meta('test') == nil)")
             .exec()
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_sender_marks_meta_dirty() {
+        let msg = new_msg_body(X_HDR_CONTENT);
+        // Simulate a message that has already been persisted by clearing
+        // the dirty flags that new_dirty() sets on construction.
+        {
+            let mut inner = msg.msg_and_id.inner.lock();
+            inner
+                .flags
+                .remove(MessageFlags::DATA_DIRTY | MessageFlags::META_DIRTY);
+        }
+
+        msg.set_sender(EnvelopeAddress::parse("new-sender@example.com").unwrap())
+            .await
+            .unwrap();
+
+        let inner = msg.msg_and_id.inner.lock();
+        assert!(
+            inner.flags.contains(MessageFlags::META_DIRTY),
+            "changing the sender must mark the metadata dirty"
+        );
+        assert!(
+            !inner.flags.contains(MessageFlags::DATA_DIRTY),
+            "changing the sender must not mark the data dirty"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_recipient_list_marks_meta_dirty() {
+        let msg = new_msg_body(X_HDR_CONTENT);
+        {
+            let mut inner = msg.msg_and_id.inner.lock();
+            inner
+                .flags
+                .remove(MessageFlags::DATA_DIRTY | MessageFlags::META_DIRTY);
+        }
+
+        msg.set_recipient_list(vec![EnvelopeAddress::parse("new-recip@example.com").unwrap()])
+            .await
+            .unwrap();
+
+        let inner = msg.msg_and_id.inner.lock();
+        assert!(
+            inner.flags.contains(MessageFlags::META_DIRTY),
+            "changing the recipient list must mark the metadata dirty"
+        );
+        assert!(
+            !inner.flags.contains(MessageFlags::DATA_DIRTY),
+            "changing the recipient list must not mark the data dirty"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_sender_after_shrink_does_not_flag_empty_data() {
+        let msg = new_msg_body(X_HDR_CONTENT);
+        // Simulate a persisted-then-shrunk message: no dirty flags and an
+        // empty in-memory data buffer (the body lives only on the spool).
+        {
+            let mut inner = msg.msg_and_id.inner.lock();
+            inner
+                .flags
+                .remove(MessageFlags::DATA_DIRTY | MessageFlags::META_DIRTY);
+            inner.data = NO_DATA.clone();
+        }
+
+        msg.set_sender(EnvelopeAddress::parse("new-sender@example.com").unwrap())
+            .await
+            .unwrap();
+
+        // Because an envelope change only dirties the metadata, save_to must
+        // not try to persist the empty data buffer, which would otherwise
+        // fail with "message data must not be empty".
+        assert!(
+            msg.get_data_if_dirty().is_none(),
+            "an envelope change must not flag the empty data buffer for saving"
+        );
+        assert!(
+            msg.needs_save(),
+            "the metadata change must still require a save"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`Message::set_sender` and `Message::set_recipient_list` mutate metadata fields (`meta.sender` / `meta.recipient`) but flag the message `DATA_DIRTY` instead of `META_DIRTY`. This is almost certainly a copy/paste bug, and it has two consequences:

1. **Envelope rewrites can be silently lost.** `save_to` only serializes the metadata blob when `META_DIRTY` is set (`get_meta_if_dirty`). Flagging `DATA_DIRTY` re-persists the (unchanged) body but never writes the new sender/recipient to the meta spool, so the rewrite can be lost after a spool reload or process restart.

2. **Spurious `message data must not be empty` errors.** If the body has already been saved and shrunk (empty in-memory data buffer, `DATA_DIRTY` cleared), then an envelope rewrite sets `DATA_DIRTY` on an empty buffer. The next save trips the `anyhow::ensure!(!data.is_empty(), "message data must not be empty")` guard in `save_to`.

   In production we saw this surface as noisy queue-maintainer requeue errors when messages were rewritten and requeued after a transient failure:
   - `Error reinserting message: ... message data must not be empty`
   - `while shrinking: <spool-id>: message data must not be empty`

## Fix

Flag `META_DIRTY` (not `DATA_DIRTY`) in `set_sender` and `set_recipient_list`, since both only touch metadata.

## Tests

Added regression tests in `crates/message/src/message.rs`:
- `set_sender_marks_meta_dirty` / `set_recipient_list_marks_meta_dirty` — assert the correct dirty flag is set (and `DATA_DIRTY` is not).
- `set_sender_after_shrink_does_not_flag_empty_data` — simulates a persisted-then-shrunk message and asserts an envelope change does not flag the empty data buffer for saving (i.e. no longer trips the `save_to` empty-data guard).

```
cargo test -p message --lib set_
running 4 tests
test message::test::set_recipient_list_marks_meta_dirty ... ok
test message::test::set_sender_after_shrink_does_not_flag_empty_data ... ok
test message::test::set_sender_marks_meta_dirty ... ok
test message::test::set_scheduling ... ok
```

Made with [Cursor](https://cursor.com)