### PR TITLE
smtp_dispatcher: recover from a stalled TLS negotiation, not just a failed one

### DIFF
--- a/crates/kumod/src/smtp_dispatcher.rs
+++ b/crates/kumod/src/smtp_dispatcher.rs
@@ -205,6 +205,40 @@ pub struct OpportunisticInsecureTlsHandshakeError {
     pub label: String,
 }
 
+/// A TLS negotiation that stalls leaves us in the same position as one that
+/// failed outright: TLS is unusable for this peer right now. `starttls`
+/// reports a stall as an error rather than `TlsStatus::FailedHandshake`
+/// though, so it bypasses the recovery that `FailedHandshake` would trigger
+/// and the message retries TLS on every attempt until it expires.
+///
+/// When the path is opportunistic and configured to reconnect in the clear,
+/// map a stall onto `FailedHandshake` so that recovery applies. A stall under
+/// `Required` is still surfaced as an error: downgrading there would violate
+/// the policy.
+fn tls_stall_as_failed_handshake(
+    error: ClientError,
+    enable_tls: Tls,
+    path_config: &EgressPathConfig,
+) -> Result<TlsStatus, ClientError> {
+    let stalled = matches!(
+        &error,
+        ClientError::TimeOutHandshake { .. }
+            | ClientError::TimeOutResponse {
+                command: Some(rfc5321::parser::Command::StartTls),
+                ..
+            }
+    );
+
+    if stalled
+        && enable_tls.is_opportunistic()
+        && path_config.opportunistic_tls_reconnect_on_failed_handshake
+    {
+        Ok(TlsStatus::FailedHandshake(error.to_string()))
+    } else {
+        Err(error)
+    }
+}
+
 impl SmtpDispatcher {
     pub async fn init(
         dispatcher: &mut Dispatcher,
@@ -847,7 +881,7 @@ impl SmtpDispatcher {
             }
             (Tls::OpportunisticInsecure, AdvTls::Yes, BrokenTls::No) => {
                 dispatcher.set_detail("STARTTLS");
-                let (enabled, label) = match client
+                let tls_status = match client
                     .starttls(TlsOptions {
                         insecure: enable_tls.allow_insecure(),
                         prefer_openssl,
@@ -860,8 +894,12 @@ impl SmtpDispatcher {
                         openssl_cipher_suites,
                         rustls_cipher_suites,
                     })
-                    .await?
+                    .await
                 {
+                    Ok(status) => status,
+                    Err(error) => tls_stall_as_failed_handshake(error, enable_tls, &path_config)?,
+                };
+                let (enabled, label) = match tls_status {
                     TlsStatus::FailedHandshake(handshake_error) => {
                         tracing::debug!(
                             "TLS handshake with {address}:{port} failed: \
@@ -925,7 +963,7 @@ impl SmtpDispatcher {
             )
             | (Tls::Opportunistic, AdvTls::Yes, BrokenTls::No) => {
                 dispatcher.set_detail("STARTTLS");
-                match client
+                let tls_status = match client
                     .starttls(TlsOptions {
                         insecure: enable_tls.allow_insecure(),
                         prefer_openssl,
@@ -938,8 +976,12 @@ impl SmtpDispatcher {
                         openssl_cipher_suites,
                         rustls_cipher_suites,
                     })
-                    .await?
+                    .await
                 {
+                    Ok(status) => status,
+                    Err(error) => tls_stall_as_failed_handshake(error, enable_tls, &path_config)?,
+                };
+                match tls_status {
                     TlsStatus::FailedHandshake(handshake_error) => {
                         self.remember_broken_tls(&dispatcher.name, &path_config)
                             .await;
@@ -1695,4 +1737,91 @@ async fn classify_record(response: &Response) -> (RecordType, IsTooManyRecipient
     };
 
     (record_type, too_many)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::time::Duration;
+
+    fn reconnecting_path() -> EgressPathConfig {
+        EgressPathConfig {
+            opportunistic_tls_reconnect_on_failed_handshake: true,
+            ..EgressPathConfig::default()
+        }
+    }
+
+    fn handshake_stall() -> ClientError {
+        ClientError::TimeOutHandshake {
+            duration: Duration::from_secs(60),
+        }
+    }
+
+    fn starttls_command_stall() -> ClientError {
+        ClientError::TimeOutResponse {
+            command: Some(rfc5321::parser::Command::StartTls),
+            duration: Duration::from_secs(60),
+        }
+    }
+
+    #[test]
+    fn stalled_handshake_recovers_when_opportunistic() {
+        for stall in [handshake_stall(), starttls_command_stall()] {
+            let status = tls_stall_as_failed_handshake(
+                stall,
+                Tls::OpportunisticInsecure,
+                &reconnecting_path(),
+            )
+            .expect("a stall under OpportunisticInsecure should become FailedHandshake");
+            assert!(matches!(status, TlsStatus::FailedHandshake(_)));
+        }
+
+        let status = tls_stall_as_failed_handshake(
+            handshake_stall(),
+            Tls::Opportunistic,
+            &reconnecting_path(),
+        )
+        .expect("a stall under Opportunistic should become FailedHandshake");
+        assert!(matches!(status, TlsStatus::FailedHandshake(_)));
+    }
+
+    #[test]
+    fn stalled_handshake_is_not_downgraded_when_tls_is_required() {
+        for tls in [Tls::Required, Tls::RequiredInsecure] {
+            tls_stall_as_failed_handshake(handshake_stall(), tls, &reconnecting_path())
+                .expect_err("a stall under a Required policy must not be downgraded");
+        }
+    }
+
+    #[test]
+    fn stall_is_not_recovered_when_reconnect_is_disabled() {
+        let path = EgressPathConfig {
+            opportunistic_tls_reconnect_on_failed_handshake: false,
+            ..EgressPathConfig::default()
+        };
+        tls_stall_as_failed_handshake(handshake_stall(), Tls::OpportunisticInsecure, &path)
+            .expect_err("without the reconnect option the stall must stay an error");
+    }
+
+    #[test]
+    fn unrelated_errors_are_passed_through() {
+        tls_stall_as_failed_handshake(
+            ClientError::NotConnected,
+            Tls::OpportunisticInsecure,
+            &reconnecting_path(),
+        )
+        .expect_err("a non-stall error must not be treated as a failed handshake");
+
+        // A timeout waiting on a different command is a protocol stall, not a
+        // TLS one, and must not silently disable TLS for the site.
+        tls_stall_as_failed_handshake(
+            ClientError::TimeOutResponse {
+                command: Some(rfc5321::parser::Command::Quit),
+                duration: Duration::from_secs(60),
+            },
+            Tls::OpportunisticInsecure,
+            &reconnecting_path(),
+        )
+        .expect_err("a non-STARTTLS command timeout must not be treated as a failed handshake");
+    }
 }

--- a/crates/rfc5321/src/client.rs
+++ b/crates/rfc5321/src/client.rs
@@ -70,6 +70,8 @@ pub enum ClientError {
     },
     #[error("Timed Out sending message payload data")]
     TimeOutData,
+    #[error("Timed Out after {duration:?} waiting for the TLS handshake to complete")]
+    TimeOutHandshake { duration: Duration },
     #[error("SSL Error: {0}")]
     SslErrorStack(#[from] openssl::error::ErrorStack),
     #[error("No usable DANE TLSA records for {hostname}: {tlsa:?}")]
@@ -134,6 +136,7 @@ impl ClientError {
             | Self::FlushError { .. }
             | Self::WriteError { .. }
             | Self::TimeOutData
+            | Self::TimeOutHandshake { .. }
             | Self::SslErrorStack(_)
             | Self::NoUsableDaneTlsa { .. } => false,
             Self::Rejected(response) => response.was_due_to_message(),
@@ -841,8 +844,7 @@ impl SmtpClient {
                         });
                         tracer.trace_event(SmtpClientTraceEvent::Closed);
                     }
-                    return Err(ClientError::TimeOutResponse {
-                        command: Some(Command::StartTls),
+                    return Err(ClientError::TimeOutHandshake {
                         duration: self.timeouts.starttls_timeout,
                     });
                 }
@@ -926,8 +928,7 @@ impl SmtpClient {
                         });
                         tracer.trace_event(SmtpClientTraceEvent::Closed);
                     }
-                    return Err(ClientError::TimeOutResponse {
-                        command: Some(Command::StartTls),
+                    return Err(ClientError::TimeOutHandshake {
                         duration: self.timeouts.starttls_timeout,
                     });
                 }

--- a/docs/changelog/main.md
+++ b/docs/changelog/main.md
@@ -209,6 +209,25 @@
 
 ## Fixes
 
+ * A TLS negotiation that *stalls* is now recovered from in the same way as one
+   that fails outright. `starttls` reports a stalled `STARTTLS` command response
+   or a stalled handshake as an error rather than
+   `TlsStatus::FailedHandshake`, so
+   [`opportunistic_tls_reconnect_on_failed_handshake`](../reference/kumo/make_egress_path/opportunistic_tls_reconnect_on_failed_handshake.md)
+   and
+   [`remember_broken_tls`](../reference/kumo/make_egress_path/remember_broken_tls.md)
+   never engaged: every attempt retried TLS against a peer known to stall, and
+   messages expired without ever being tried in the clear. A stall on an
+   opportunistic path configured to reconnect in the clear is now mapped onto
+   `FailedHandshake` so the existing recovery applies. A stall under a
+   `Required` policy is still reported as an error and is never downgraded.
+
+ * A stalled TLS handshake is now reported as its own error, `Timed Out after
+   ... waiting for the TLS handshake to complete`, rather than being described
+   as a timeout waiting for a response to `cmd=STARTTLS`. The two failures are
+   diagnostically very different — the peer answered `220` and then went quiet
+   in the handshake — but were previously indistinguishable in logs.
+
  * RFC 2822 date parsing now tolerates an obsolete alphabetic time zone such
    as the `UTC` that Amazon SES emits in its bounce reports, which strict
    parsing would otherwise reject. A recognized abbreviation resolves to its


### PR DESCRIPTION
## Summary

A TLS negotiation that *stalls* is never recovered from, even on an opportunistic path that is explicitly configured to fall back to cleartext.

`starttls()` reports a stall — either the `STARTTLS` command response timing out, or (since 1b726e4d) the handshake that follows timing out — as a `ClientError`. Both `starttls()` call sites in `smtp_dispatcher.rs` invoke it as `.await?`, so the error propagates straight out of the function and the `TlsStatus::FailedHandshake` arms are never reached. Everything those arms do is therefore skipped:

- `remember_broken_tls` is never recorded, so the next attempt has no idea the peer's TLS stalls
- `opportunistic_tls_reconnect_on_failed_handshake` never fires, so the message is never retried in the clear

The result is a loop: every attempt re-offers `STARTTLS` to a peer already known to stall, waits the full `starttls_timeout`, fails identically, and the message eventually expires — even when the path is `OpportunisticInsecure` and the peer accepts the mail perfectly well unencrypted. Raising `starttls_timeout` makes it worse, not better, because each doomed attempt holds its connection slot proportionally longer.

Only a handshake that *fails* is recovered from today. One that hangs is not, though the situation it leaves us in is identical.

## There is an existing workaround, which is why this is a papercut and not a defect

To be upfront: this is already solvable with configuration as it stands, and I should say so rather than overstate the case. A single TSA automation rule handles it:

```toml
[["default".automation]]
regex = "Timed Out waiting .* for response to cmd=STARTTLS"
action = {SetConfig={name="enable_tls", value="Disabled"}}
duration = "1hr"
match_internal = true
```

I verified this against the verbatim production failure string and it validates with no warnings and matches, yielding `SetConfig(EgressPathConfigValue { name: "enable_tls", value: String("Disabled") })`. So an operator who knows to write it is covered, and I'm deploying it on our fleet as the immediate mitigation.

What I'd suggest is still worth fixing, and you may reasonably disagree:

1. `opportunistic_tls_reconnect_on_failed_handshake` exists precisely to deliver in the clear when opportunistic TLS doesn't work out. A stall is a case where it doesn't work out, but the option silently doesn't cover it. The gap isn't discoverable from the option's name or its docs.
2. The workaround is reactive. It needs the failure to occur, be logged, published to TSA, and distributed back, so messages fail in the interim. The in-process fallback acts on the first stall.
3. `SetConfig{enable_tls="Disabled"}` is blunt: as a `default` rule it applies regardless of the path's TLS policy, so it will happily downgrade a path that asked for `Required`. The change here refuses to do that.
4. It requires running TSA. `opportunistic_tls_reconnect_on_failed_handshake` does not.

If you'd rather close this and document the TSA recipe against the option instead, that's a perfectly good outcome and I'm happy to send a docs PR for that instead.

## What we saw

One destination — a small municipal mail gateway serving a few dozen `.gov` domains — accounted for the bulk of it: about 98% of attempts failed on `cmd=STARTTLS` while roughly 1% delivered, with messages retried 8-10 times over ~1.75h (p50) before expiring. Across the fleet it was ~110k failed attempts / ~16.8k distinct messages / ~5.5k permanently expired messages per week.

The destination was healthy the whole time. Probing it from the same egress IP that was failing, it advertises `STARTTLS`, answers `220 Go ahead with TLS` in 0.02s, and completes a TLSv1.3 handshake in 0.08s. It also accepts the mail in cleartext (`MAIL FROM`/`RCPT TO` both `250`), which is exactly the fallback that was configured and never ran. I was not able to reproduce the stall itself at low request rates, so I can't say what triggers it at the peer — only that when it happens we handle it in the most expensive possible way.

## The change

Map a stall onto `FailedHandshake` when the path is opportunistic *and* configured to reconnect in the clear, so the existing recovery applies. The policy guards in the two `FailedHandshake` arms are already correct, so this is deliberately small and adds no new configuration:

- `Opportunistic` / `OpportunisticInsecure` with `opportunistic_tls_reconnect_on_failed_handshake` → recovered, delivers in the clear
- `Required` / `RequiredInsecure` → still an error, never downgraded
- `opportunistic_tls_reconnect_on_failed_handshake = false` → unchanged
- any error that is not a TLS stall, including a timeout waiting on some other command → passed through unchanged

Note the fallback path this routes into discards the connection and reconnects, so it does not need the socket that the timed-out handshake future consumed.

## Diagnostics

A stalled handshake now has its own error, `Timed Out after ... waiting for the TLS handshake to complete`, instead of being reported as a timeout waiting for a response to `cmd=STARTTLS`.

Since 1b726e4d bounded the handshake using `starttls_timeout` and reported the timeout as `TimeOutResponse { command: StartTls }`, a peer that never answers the command and a peer that answers `220` and then goes quiet mid-handshake produce byte-identical log lines. That cost us real time: the logs pointed at the command exchange, which we could show responding instantly, while the stall was actually elsewhere. This part seems worth having regardless of what you decide about the rest.

## Testing

`cargo test -p kumod --bin kumod smtp_dispatcher` — 4 new tests covering the opportunistic mapping (both stall variants), the `Required` and `RequiredInsecure` refusal, the `opportunistic_tls_reconnect_on_failed_handshake = false` case, and pass-through of unrelated errors including a non-`STARTTLS` command timeout.

`cargo check -p kumod -p rfc5321` clean, `cargo fmt` clean.

## Relationship to #539 / #542

#542 was my earlier attempt at the adjacent problem (the unbounded handshake), which you fixed independently and more thoroughly in 1b726e4d plus the dispatcher progress watchdog. This is the follow-on: the handshake is now bounded, but the timeout it produces still bypasses the opportunistic fallback, so an opportunistic path treats a stalling peer as undeliverable instead of delivering in the clear.
