### PR TITLE
Fix unescaped parentheses in two community bounce rules

### DIFF
--- a/assets/community/bounces.toml
+++ b/assets/community/bounces.toml
@@ -62,7 +62,7 @@ BadDomain = [
   "^556.+Recipient address has a null MX"
 ]
 InactiveMailbox = [
-  "This mailbox is disabled (554\\.30)", # Yahoo! Mail
+  "This mailbox is disabled \\(554\\.30\\)", # Yahoo! Mail
   "^550.+Account is not active",
   "^550.+User account not activated",
   "^550.+Account Closed, Please Remove", # comcast.net
@@ -80,7 +80,7 @@ QuotaIssues = [
   "^552.+user's mailbox quota exceeded",
   "^550.+Mailbox is full / Blocks limit exceeded / Inode limit exceeded",
   "^552.+Mailbox full",
-  "^554.+Quota exceeded (mailbox for user is full)",
+  "^554.+Quota exceeded \\(mailbox for user is full\\)",
   "^552.+extended quota violation",
   "^552.+OverQuotaPerm",
   "^550.+account is overquota",

--- a/crates/bounce-classify/src/lib.rs
+++ b/crates/bounce-classify/src/lib.rs
@@ -310,4 +310,33 @@ second_file = ["bbb", "ccc"]
             );
         }
     }
+
+    #[test]
+    fn test_bounce_classify_community() {
+        let mut builder = BounceClassifierBuilder::new();
+        builder
+            .merge_toml_file("../../assets/community/bounces.toml")
+            .unwrap();
+        let classifier = builder.build().unwrap();
+
+        let corpus = &[
+            // Yahoo! Mail dormant account, verbatim from a production log
+            // (Response::to_single_line(): code + content; no enhanced code
+            // was present). The parentheses are literal text in the response,
+            // so they must be escaped in the rule.
+            (
+                "554 30 Sorry, your message to user@yahoo.com cannot be \
+                 delivered. This mailbox is disabled (554.30).",
+                PreDefinedBounceClass::InactiveMailbox,
+            ),
+        ];
+
+        for &(input, output) in corpus {
+            assert_eq!(
+                classifier.classify_str(input),
+                output.into(),
+                "expected {input} -> {output:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Both rules contain parentheses that are literal text in the provider's response but are left unescaped, so the regex engine reads them as a capture group and the rules can never match:

  InactiveMailbox: "This mailbox is disabled (554\\.30)"
    looks for `disabled 554.30`, but Yahoo sends `disabled (554.30)`

  QuotaIssues: "^554.+Quota exceeded (mailbox for user is full)"
    same defect

Effect: Yahoo dormant-account rejections classify as `Uncategorized` rather than `InactiveMailbox`, so senders driving suppression from the classification never retire those addresses and keep mailing disabled mailboxes.

Adds test_bounce_classify_community using a bounce string captured in production. Nothing covered assets/community/bounces.toml before this, which is why the defect went unnoticed. validate-bounces cannot catch it either: the broken rules parse and compile without complaint.

The QuotaIssues rule is fixed but has no test - I have no captured example of that string, and its ^554 anchor may be wrong independently (the message is documented in the wild with 552, which iana.toml already matches).