### PR TITLE
Add a configurable timeout to Vault secret reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "config",
+ "duration-serde",
  "mlua",
  "serde",
  "serde_bytes",

--- a/crates/data-loader/Cargo.toml
+++ b/crates/data-loader/Cargo.toml
@@ -10,6 +10,7 @@ impl = ["dep:vaultrs", "dep:config", "dep:mlua", "dep:tokio"]
 [dependencies]
 anyhow = {workspace=true}
 config = {path="../config", optional=true}
+duration-serde = {path="../duration-serde"}
 mlua = {workspace=true, features=["vendored", "lua54", "async", "send", "serialize"], optional=true}
 serde = {workspace=true}
 serde_bytes.workspace = true

--- a/crates/data-loader/src/lib.rs
+++ b/crates/data-loader/src/lib.rs
@@ -25,7 +25,7 @@ pub enum KeySource {
         #[serde(default = "default_vault_key")]
         vault_key: String,
         #[serde(default = "default_vault_timeout", with = "duration_serde")]
-        vault_timeout: Option<Duration>,
+        vault_timeout: Duration,
     },
     Event {
         event_name: String,
@@ -401,23 +401,20 @@ mod test {
 
         Ok(())
     }
-
-    /// Accept connections but never respond to them; this is the shape
-    /// of vault outage that hangs a read that has no timeout.
-    fn spawn_black_hole() -> anyhow::Result<String> {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-        let address = format!("http://{}", listener.local_addr()?);
-        std::thread::spawn(move || {
-            let mut accepted = vec![];
-            while let Ok((stream, _)) = listener.accept() {
-                accepted.push(stream);
-            }
-        });
-        Ok(address)
-    }
-
     #[tokio::test]
     async fn test_vault_timeout() -> anyhow::Result<()> {
+    // Accept connections but never answer them, matching the vault outage
+    // that hangs a read with no timeout. The JoinSet aborts the accept loop
+    // when it drops at the end of the test.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = format!("http://{}", listener.local_addr()?);
+    let mut black_hole = tokio::task::JoinSet::new();
+    black_hole.spawn(async move {
+        let mut accepted = vec![];
+        while let Ok((stream, _)) = listener.accept().await {
+            accepted.push(stream);
+        }
+    });    
         let source = KeySource::Vault {
             vault_address: Some(spawn_black_hole()?),
             vault_token: Some(KEY.to_string()),
@@ -439,13 +436,6 @@ mod test {
         assert!(
             err.contains("kv2::read vault_mount=secret, vault_path=foo"),
             "{err}"
-        );
-
-        // Deliberately loose, so that a loaded CI machine cannot make this
-        // flaky while it still fails if vault_timeout stops being applied.
-        assert!(
-            elapsed < Duration::from_secs(10),
-            "expected the 1s vault_timeout to bound the read, took {elapsed:?}"
         );
 
         Ok(())

--- a/crates/data-loader/src/lib.rs
+++ b/crates/data-loader/src/lib.rs
@@ -5,6 +5,7 @@ use config::{any_err, from_lua_value, get_or_create_sub_module};
 #[cfg(feature = "impl")]
 use mlua::Lua;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 #[cfg(feature = "impl")]
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
 
@@ -23,6 +24,8 @@ pub enum KeySource {
         vault_path: String,
         #[serde(default = "default_vault_key")]
         vault_key: String,
+        #[serde(default = "default_vault_timeout", with = "duration_serde")]
+        vault_timeout: Option<Duration>,
     },
     Event {
         event_name: String,
@@ -32,6 +35,10 @@ pub enum KeySource {
 
 fn default_vault_key() -> String {
     "key".to_string()
+}
+
+fn default_vault_timeout() -> Option<Duration> {
+    Some(Duration::from_secs(30))
 }
 
 #[cfg(feature = "impl")]
@@ -48,6 +55,7 @@ impl KeySource {
                 vault_mount,
                 vault_path,
                 vault_key,
+                vault_timeout,
             } => {
                 let address = match vault_address {
                     Some(a) => a.to_string(),
@@ -70,6 +78,7 @@ impl KeySource {
                     VaultClientSettingsBuilder::default()
                         .address(address)
                         .token(token)
+                        .timeout(*vault_timeout)
                         .build()?,
                 )?;
 
@@ -283,6 +292,7 @@ mod test {
                 vault_mount: "secret".to_string(),
                 vault_path: path.to_string(),
                 vault_key: "key".to_string(),
+                vault_timeout: default_vault_timeout(),
             }
         }
     }
@@ -366,6 +376,7 @@ mod test {
             vault_mount: "secret".to_string(),
             vault_path: "custom_key".to_string(),
             vault_key: "custom_field".to_string(),
+            vault_timeout: default_vault_timeout(),
         };
 
         // This should fail because the vault secret has "key" but we're looking for "custom_field"
@@ -382,10 +393,60 @@ mod test {
             vault_mount: "secret".to_string(),
             vault_path: "custom_key".to_string(),
             vault_key: "key".to_string(),
+            vault_timeout: default_vault_timeout(),
         };
 
         let data = source.get().await?;
         assert_eq!(data, b"custom_value");
+
+        Ok(())
+    }
+
+    /// Accept connections but never respond to them; this is the shape
+    /// of vault outage that hangs a read that has no timeout.
+    fn spawn_black_hole() -> anyhow::Result<String> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let address = format!("http://{}", listener.local_addr()?);
+        std::thread::spawn(move || {
+            let mut accepted = vec![];
+            while let Ok((stream, _)) = listener.accept() {
+                accepted.push(stream);
+            }
+        });
+        Ok(address)
+    }
+
+    #[tokio::test]
+    async fn test_vault_timeout() -> anyhow::Result<()> {
+        let source = KeySource::Vault {
+            vault_address: Some(spawn_black_hole()?),
+            vault_token: Some(KEY.to_string()),
+            vault_mount: "secret".to_string(),
+            vault_path: "foo".to_string(),
+            vault_key: "key".to_string(),
+            vault_timeout: Some(Duration::from_secs(1)),
+        };
+
+        // The outer timeout is much longer than vault_timeout; it is here
+        // so that a regression fails this test rather than hanging CI.
+        let start = std::time::Instant::now();
+        let result = timeout(Duration::from_secs(30), source.get())
+            .await
+            .context("vault_timeout did not bound the read")?;
+        let elapsed = start.elapsed();
+
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(
+            err.contains("kv2::read vault_mount=secret, vault_path=foo"),
+            "{err}"
+        );
+
+        // Deliberately loose, so that a loaded CI machine cannot make this
+        // flaky while it still fails if vault_timeout stops being applied.
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "expected the 1s vault_timeout to bound the read, took {elapsed:?}"
+        );
 
         Ok(())
     }

--- a/crates/data-loader/src/lib.rs
+++ b/crates/data-loader/src/lib.rs
@@ -37,8 +37,8 @@ fn default_vault_key() -> String {
     "key".to_string()
 }
 
-fn default_vault_timeout() -> Option<Duration> {
-    Some(Duration::from_secs(30))
+fn default_vault_timeout() -> Duration {
+    Duration::from_secs(30)
 }
 
 #[cfg(feature = "impl")]
@@ -78,7 +78,7 @@ impl KeySource {
                     VaultClientSettingsBuilder::default()
                         .address(address)
                         .token(token)
-                        .timeout(*vault_timeout)
+                        .timeout(Some(*vault_timeout))
                         .build()?,
                 )?;
 
@@ -401,41 +401,39 @@ mod test {
 
         Ok(())
     }
+
     #[tokio::test]
     async fn test_vault_timeout() -> anyhow::Result<()> {
-    // Accept connections but never answer them, matching the vault outage
-    // that hangs a read with no timeout. The JoinSet aborts the accept loop
-    // when it drops at the end of the test.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
-    let address = format!("http://{}", listener.local_addr()?);
-    let mut black_hole = tokio::task::JoinSet::new();
-    black_hole.spawn(async move {
-        let mut accepted = vec![];
-        while let Ok((stream, _)) = listener.accept().await {
-            accepted.push(stream);
-        }
-    });    
+        // Never accepted from: the kernel completes the handshake into the
+        // backlog, so the read connects and then waits forever for a response.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+
         let source = KeySource::Vault {
-            vault_address: Some(spawn_black_hole()?),
+            vault_address: Some(format!("http://127.0.0.1:{port}")),
             vault_token: Some(KEY.to_string()),
             vault_mount: "secret".to_string(),
             vault_path: "foo".to_string(),
             vault_key: "key".to_string(),
-            vault_timeout: Some(Duration::from_secs(1)),
+            vault_timeout: Duration::from_secs(1),
         };
 
-        // The outer timeout is much longer than vault_timeout; it is here
-        // so that a regression fails this test rather than hanging CI.
-        let start = std::time::Instant::now();
+        // So that a regression fails the test rather than hanging CI.
         let result = timeout(Duration::from_secs(30), source.get())
             .await
             .context("vault_timeout did not bound the read")?;
-        let elapsed = start.elapsed();
 
-        let err = format!("{:#}", result.unwrap_err());
-        assert!(
-            err.contains("kv2::read vault_mount=secret, vault_path=foo"),
-            "{err}"
+        // The port is kernel-assigned; rewrite it to compare exactly.
+        let err = format!("{:#}", result.unwrap_err()).replace(&format!(":{port}"), ":PORT");
+        assert_eq!(
+            err,
+            "kv2::read vault_mount=secret, vault_path=foo \
+             Vault { vault_address: Some(\"http://127.0.0.1:PORT\"), \
+             vault_token: Some(\"woot\"), vault_mount: \"secret\", \
+             vault_path: \"foo\", vault_key: \"key\", vault_timeout: 1s }: \
+             An error occurred with the request: Error sending HTTP request: \
+             error sending request for url (http://127.0.0.1:PORT/v1/secret/data/foo?): \
+             operation timed out"
         );
 
         Ok(())

--- a/docs/changelog/main.md
+++ b/docs/changelog/main.md
@@ -15,6 +15,13 @@
    [store_deadline](../reference/kumo/define_spool/rocks_params.md#store_deadline)
    rocks_params field.
 
+ * Reads from a HashiCorp Vault [keysource](../reference/keysource.md) now
+   time out after 30 seconds rather than waiting indefinitely. A vault
+   endpoint that accepted the connection but never answered would
+   previously park the calling lua forever, which could hold a graceful
+   shutdown open when the read happened in a connection handler. Tunable
+   via the new `vault_timeout` [keysource](../reference/keysource.md) field.
+
  * The `resolve-shaping-domain` script's default output has changed.
    Pass `--json-config` to restore the previous byte-for-byte
    pretty-JSON output of the path config. Run

--- a/docs/changelog/main.md
+++ b/docs/changelog/main.md
@@ -16,11 +16,9 @@
    rocks_params field.
 
  * Reads from a HashiCorp Vault [keysource](../reference/keysource.md) now
-   time out after 30 seconds rather than waiting indefinitely. A vault
-   endpoint that accepted the connection but never answered would
-   previously park the calling lua forever, which could hold a graceful
-   shutdown open when the read happened in a connection handler. Tunable
+   time out after 30 seconds rather than waiting indefinitely. Tunable
    via the new `vault_timeout` [keysource](../reference/keysource.md) field.
+   Thanks to @ivanmp91! #585
 
  * The `resolve-shaping-domain` script's default output has changed.
    Pass `--json-config` to restore the previous byte-for-byte

--- a/docs/reference/keysource.md
+++ b/docs/reference/keysource.md
@@ -88,6 +88,11 @@ local vault_signer = kumo.dkim.rsa_sha256_signer {
     -- {{since('2025.10.06-5ec871ab', inline=True)}}
     -- Defaults to "key" if not specified
     -- vault_key = "my_custom_key_name"
+
+    -- Optional: bound how long the request to vault may take
+    -- {{since('dev', inline=True)}}
+    -- Defaults to "30 seconds"
+    -- vault_timeout = "10 seconds"
   },
 }
 ```
@@ -116,6 +121,11 @@ And store it in vault like this:
 ```console
 $ vault kv put -mount=secret dkim/example.org private_key=@example-private-dkim-key.pem
 ```
+
+Requests to vault are bounded by `vault_timeout` {{since('dev', inline=True)}},
+which defaults to `30 seconds`; see
+[kumo.secrets.load](kumo.secrets/load.md#bounding-a-vault-read) for why that
+matters.
 
 ### Callback/Event based Data Source
 

--- a/docs/reference/keysource.md
+++ b/docs/reference/keysource.md
@@ -123,10 +123,7 @@ $ vault kv put -mount=secret dkim/example.org private_key=@example-private-dkim-
 ```
 
 Requests to vault are bounded by `vault_timeout` {{since('dev', inline=True)}},
-which defaults to `30 seconds`; see
-[kumo.secrets.load](kumo.secrets/load.md#bounding-a-vault-read) for why that
-matters.
-
+which defaults to `30 seconds`.  Earlier releases had no timeout.
 ### Callback/Event based Data Source
 
 {{since('2025.12.02-67ee9e96')}}

--- a/docs/reference/kumo.secrets/load.md
+++ b/docs/reference/kumo.secrets/load.md
@@ -16,32 +16,10 @@ local passwd = kumo.secrets.load {
   vault_path = 'example.com-passwd',
   -- Optional: specify a custom key name (defaults to "key")
   -- vault_key = "password"
-  -- Optional: bound the request (defaults to "30 seconds")
+  -- Optional: bound the request (defaults to "30 seconds") {{since('dev', inline=True)}}
   -- vault_timeout = "10 seconds"
 }
 request:basic_auth('username', passwd)
 
 local response = request:send()
 ```
-
-## Bounding a vault read
-
-{{since('dev')}}
-
-Vault reads are bounded by the [keysource](../keysource.md)'s `vault_timeout`,
-which defaults to `30 seconds`. When the timeout is hit, `kumo.secrets.load`
-raises an error, which you can catch with `pcall`.
-
-Bounding this matters more than it might appear. `kumo.secrets.load` is
-often called from a connection handler such as
-[smtp_server_auth_plain](../events/smtp_server_auth_plain.md), and an SMTP
-session holds an activity token for its whole lifetime. A vault endpoint
-that accepts the TCP connection but never answers would, before this
-option existed, park that session forever — and a graceful shutdown waits
-for every session to finish, so one stuck read can hold the whole process
-open until it is killed.
-
-Note that
-[data_processing_timeout](../kumo/start_esmtp_listener/data_processing_timeout.md)
-does not cover this: it bounds the post-`DATA` callbacks only, not
-callbacks such as `smtp_server_auth_plain` that run earlier in the session.

--- a/docs/reference/kumo.secrets/load.md
+++ b/docs/reference/kumo.secrets/load.md
@@ -16,8 +16,32 @@ local passwd = kumo.secrets.load {
   vault_path = 'example.com-passwd',
   -- Optional: specify a custom key name (defaults to "key")
   -- vault_key = "password"
+  -- Optional: bound the request (defaults to "30 seconds")
+  -- vault_timeout = "10 seconds"
 }
 request:basic_auth('username', passwd)
 
 local response = request:send()
 ```
+
+## Bounding a vault read
+
+{{since('dev')}}
+
+Vault reads are bounded by the [keysource](../keysource.md)'s `vault_timeout`,
+which defaults to `30 seconds`. When the timeout is hit, `kumo.secrets.load`
+raises an error, which you can catch with `pcall`.
+
+Bounding this matters more than it might appear. `kumo.secrets.load` is
+often called from a connection handler such as
+[smtp_server_auth_plain](../events/smtp_server_auth_plain.md), and an SMTP
+session holds an activity token for its whole lifetime. A vault endpoint
+that accepts the TCP connection but never answers would, before this
+option existed, park that session forever — and a graceful shutdown waits
+for every session to finish, so one stuck read can hold the whole process
+open until it is killed.
+
+Note that
+[data_processing_timeout](../kumo/start_esmtp_listener/data_processing_timeout.md)
+does not cover this: it bounds the post-`DATA` callbacks only, not
+callbacks such as `smtp_server_auth_plain` that run earlier in the session.


### PR DESCRIPTION
## The problem

`KeySource::Vault` builds its client without setting a request timeout. `vaultrs`' `VaultClientSettings.timeout` is `Option<Duration>` and defaults to `None`.

A vault endpoint that completes the TCP handshake and then never answers therefore parks the calling lua forever. In kumod an SMTP session holds an `Activity` token for its whole lifetime and `LifeCycle::wait_for_shutdown` waits for every `Activity` to drop with no timeout of its own, so one session parked in a vault read holds the entire process's graceful shutdown open until it is SIGKILLed.

## To reproduce

Tested against `2026.06.23-f3af1cd0`, running the official `ghcr.io/kumocorp/kumomta:latest` image. Start a black-holed vault — a listener that accepts the connection and never responds. A *closed* port fails fast and does not reproduce this:

```console
$ socat TCP-LISTEN:8200,fork,reuseaddr SYSTEM:'sleep 900' &
```

Use a policy with a normal ESMTP listener plus an AUTH handler that reads from vault:

```lua
kumo.on('smtp_server_auth_plain', function(authz, authc, password, conn_meta)
  pcall(kumo.secrets.load, {
    vault_mount = 'secret',
    vault_path = 'accounts/1',
    vault_key = 'password',
  })
  return false
end)
```

Run kumod with `VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=dummy`, open a session that authenticates (`swaks --tls --auth PLAIN ...`), then SIGTERM kumod a couple of seconds later.

**Observed:** kumod never exits, logging this every 15s under `KUMOD_LOG=kumo_server_lifecycle=info`:

```
2026-08-15T10:43:34.460971Z  INFO       main kumo_server_lifecycle: Still waiting for 1 pending activities... smtp_server process client 172.17.0.1:52464 -> 172.17.0.3:2025
```

Exactly one activity — the session. The AUTH client never gets a response either.

**Expected:** the vault read gives up after a bounded interval, the policy sees an error it can turn into a 4xx/5xx, the session ends, and shutdown completes.

## The change

A `vault_timeout` field on the `Vault` keysource variant, passed to the settings builder:

```rust
#[serde(default = "default_vault_timeout", with = "duration_serde")]
vault_timeout: Duration,
```

Docs updated in `keysource.md`, `kumo.secrets/load.md` and the changelog. `test_vault_timeout` points a `KeySource::Vault` at a listener that is bound but never accepted from, with a 1s timeout, and asserts the exact error string, wrapped in an outer 30s `tokio::time::timeout` so a regression fails the test rather than hanging CI.