### PR TITLE
Ability to add character set alias

### DIFF
--- a/crates/kumod/src/mod_kumo.rs
+++ b/crates/kumod/src/mod_kumo.rs
@@ -22,8 +22,39 @@ use spool::SpoolId;
 use std::sync::Arc;
 use throttle::ThrottleSpec;
 
+/// Register `alias` as another name for the charset `target`, updating the
+/// global alias table that the mail parser consults while decoding.
+/// `target` must be a charset already known to the decoder.
+pub fn add_charset_alias(alias: &str, target: &str) -> anyhow::Result<()> {
+    mailparsing::resolve_charset(target).ok_or_else(|| {
+        anyhow::anyhow!("add_charset_alias: unknown charset target '{target}' for alias '{alias}'")
+    })?;
+    mailparsing::CHARSET_ALIASES
+        .write()
+        .expect("charset alias registry lock poisoned")
+        .insert(alias.to_ascii_lowercase(), target.to_ascii_lowercase());
+    Ok(())
+}
+
 pub fn register(lua: &Lua) -> anyhow::Result<()> {
     let kumo_mod = get_or_create_module(lua, "kumo")?;
+
+    // Accepts a list of `{target_charset, {alias, ...}}` pairs, eg:
+    //   kumo.add_charset_alias{ {'euc-kr', {'ms949', 'cp949'}} }
+    kumo_mod.set(
+        "add_charset_alias",
+        lua.create_function(|_, mappings: mlua::Table| {
+            for entry in mappings.sequence_values::<mlua::Table>() {
+                let entry = entry?;
+                let target: String = entry.get(1)?;
+                let aliases: Vec<String> = entry.get(2)?;
+                for alias in &aliases {
+                    add_charset_alias(alias, &target).map_err(any_err)?;
+                }
+            }
+            Ok(())
+        })?,
+    )?;
 
     crate::http_server::admin_suspend_ready_q_v1::register(lua)?;
     crate::http_server::admin_suspend_v1::register(lua)?;

--- a/crates/mailparsing/src/charset.rs
+++ b/crates/mailparsing/src/charset.rs
@@ -1,0 +1,69 @@
+use charset_normalizer_rs::Encoding;
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+/// Well-known names that are byte-compatible with a supported encoding but are
+/// absent from the standard label table. Pre-registered so common mail decodes
+/// without configuration; runtime aliases can add more or override these.
+const BUILTIN_ALIASES: &[(&str, &str)] = &[
+    ("ms949", "euc-kr"),
+    ("cp949", "euc-kr"),
+    ("uhc", "euc-kr"),
+    ("x-windows-949", "euc-kr"),
+    ("cp932", "shift_jis"),
+    ("cp936", "gbk"),
+    ("ms936", "gbk"),
+    ("cp950", "big5"),
+    ("iso-8859-8-i", "iso-8859-8"),
+];
+
+/// Runtime-registered aliases, populated via `kumo.add_charset_alias`.
+pub static CHARSET_ALIASES: RwLock<BTreeMap<String, String>> = RwLock::new(BTreeMap::new());
+
+/// Resolve a charset name. Runtime aliases take precedence, then the standard
+/// label table, then the built-in aliases.
+pub fn resolve_charset(name: &str) -> Option<&'static Encoding> {
+    let lower = name.to_ascii_lowercase();
+
+    if let Some(target) = CHARSET_ALIASES
+        .read()
+        .expect("charset alias registry lock poisoned")
+        .get(&lower)
+    {
+        return Encoding::by_name(target);
+    }
+
+    if let Some(enc) = Encoding::by_name(name) {
+        return Some(enc);
+    }
+
+    BUILTIN_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == lower)
+        .and_then(|(_, target)| Encoding::by_name(target))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn builtin_alias_resolution() {
+        let ms949 = resolve_charset("MS949").expect("ms949 is built-in");
+        assert_eq!(ms949.name(), Encoding::by_name("euc-kr").unwrap().name());
+    }
+
+    #[test]
+    fn runtime_alias_resolution() {
+        assert!(resolve_charset("x-test-custom").is_none());
+        CHARSET_ALIASES
+            .write()
+            .unwrap()
+            .insert("x-test-custom".to_string(), "euc-kr".to_string());
+        let via_alias = resolve_charset("X-Test-Custom").expect("alias should resolve");
+        assert_eq!(
+            via_alias.name(),
+            Encoding::by_name("euc-kr").unwrap().name()
+        );
+    }
+}

--- a/crates/mailparsing/src/header.rs
+++ b/crates/mailparsing/src/header.rs
@@ -663,6 +663,20 @@ Ok(
     }
 
     #[test]
+    fn test_charset_alias_decode() {
+        // MS949 is a built-in alias for euc-kr; no registration required.
+        let (header, _size) = Header::parse("Subject: =?MS949?B?W7+luuq3ucDOXQ==?=").unwrap();
+        k9::snapshot!(
+            header.as_unstructured(),
+            r#"
+Ok(
+    "[엠브레인]",
+)
+"#
+        );
+    }
+
+    #[test]
     fn test_unstructured_encode() {
         let header = Header::new_unstructured("Subject", "hello there");
         k9::snapshot!(header.value, "hello there");

--- a/crates/mailparsing/src/lib.rs
+++ b/crates/mailparsing/src/lib.rs
@@ -1,4 +1,5 @@
 mod builder;
+mod charset;
 mod conformance;
 mod datetime;
 mod error;
@@ -14,6 +15,7 @@ pub use error::MailParsingError;
 pub type Result<T> = std::result::Result<T, MailParsingError>;
 
 pub use builder::*;
+pub use charset::{resolve_charset, CHARSET_ALIASES};
 pub use conformance::*;
 pub use datetime::parse_rfc2822_date;
 pub use header::{Header, HeaderParseResult, MessageConformance};

--- a/crates/mailparsing/src/mimepart.rs
+++ b/crates/mailparsing/src/mimepart.rs
@@ -2,8 +2,8 @@ use crate::header::{HeaderParseResult, MessageConformance};
 use crate::headermap::HeaderMap;
 use crate::strings::IntoSharedString;
 use crate::{
-    has_lone_cr_or_lf, BStringUtf8, Header, MailParsingError, MessageID, MimeParameterEncoding,
-    MimeParameters, Result, SharedString,
+    has_lone_cr_or_lf, resolve_charset, BStringUtf8, Header, MailParsingError, MessageID,
+    MimeParameterEncoding, MimeParameters, Result, SharedString,
 };
 use bstr::{BStr, BString, ByteSlice};
 use charset_normalizer_rs::entity::NormalizerSettings;
@@ -100,7 +100,7 @@ impl Rfc2045Info {
         let charset = charset.unwrap_or_else(|| "us-ascii".into());
 
         let charset = match charset.to_str() {
-            Ok(charset) => Encoding::by_name(&*charset).ok_or_else(|| {
+            Ok(charset) => resolve_charset(&charset).ok_or_else(|| {
                 MailParsingError::BodyParse(format!("unsupported charset {charset}"))
             }),
             Err(_) => Err(MailParsingError::BodyParse(format!(
@@ -2124,6 +2124,22 @@ Body\r
 
         eprintln!("{rebuilt:?}");
         assert_eq!(rebuilt.body().unwrap().to_string_lossy().trim(), "تست");
+    }
+
+    #[test]
+    fn body_charset_alias_decode() {
+        // MS949 is a built-in alias for euc-kr; no registration required.
+        // "[엠브레인]" as euc-kr/CP949 bytes, base64 encoded.
+        const CONTENT: &str = "Subject: hello\r\n\
+            Content-Type: text/plain; charset=\"MS949\"\r\n\
+            Content-Transfer-Encoding: base64\r\n\
+            \r\n\
+            W7+luuq3ucDOXQ==\r\n";
+
+        let msg = MimePart::parse(CONTENT).unwrap();
+        let body = msg.body().unwrap();
+        assert!(matches!(body, DecodedBody::Text(_)));
+        assert_eq!(body.to_string_lossy(), "[엠브레인]");
     }
 
     #[test]

--- a/crates/mailparsing/src/rfc5322_parser.rs
+++ b/crates/mailparsing/src/rfc5322_parser.rs
@@ -1,7 +1,6 @@
 use crate::headermap::EncodeHeaderValue;
-use crate::{MailParsingError, Result, SharedString};
+use crate::{resolve_charset, MailParsingError, Result, SharedString};
 use bstr::{BStr, BString, ByteSlice, ByteVec};
-use charset_normalizer_rs::Encoding;
 use nom::branch::alt;
 use nom::bytes::complete::{take_while, take_while1, take_while_m_n};
 use nom::combinator::{all_consuming, map, opt, recognize};
@@ -1053,7 +1052,7 @@ fn encoded_word(input: Span) -> IResult<Span, BString> {
         )
     })?;
 
-    let charset = Encoding::by_name(&*charset_name).ok_or_else(|| {
+    let charset = resolve_charset(&charset_name).ok_or_else(|| {
         make_context_error(
             input,
             format!("encoded_word: unsupported charset '{charset_name}'"),
@@ -2171,7 +2170,7 @@ impl MimeParameters {
 
         for ele in elements {
             if let Some(cset) = ele.mime_charset.as_ref().and_then(|b| b.to_str().ok()) {
-                mime_charset = Encoding::by_name(&*cset);
+                mime_charset = resolve_charset(&cset);
             }
 
             match ele.encoding {

--- a/docs/reference/kumo/add_charset_alias.md
+++ b/docs/reference/kumo/add_charset_alias.md
@@ -1,0 +1,24 @@
+# kumo.add_charset_alias
+
+```lua
+kumo.add_charset_alias{ {'target', {'alias1', 'alias2'}}}
+```
+
+{{since('dev')}}
+
+The same character set is often known by different names depending on the
+operating system or application that produced a message. A message using a name
+KumoMTA does not recognize fails to decode, even when the bytes are valid.
+
+`kumo.add_charset_alias` registers additional names for a `target` character set
+so those messages decode correctly. The `target` must be a character set KumoMTA
+already recognizes. Aliases apply to both encoded-word headers and MIME bodies,
+and should be registered from your [init](../events/init.md) event handler.
+
+```lua
+kumo.on('init', function()
+  kumo.add_charset_alias{
+    { 'euc-kr', { 'ms949', 'cp949' } },
+  }
+end)
+```


### PR DESCRIPTION
Charset MS949 is not decoded through kumomta.
Subject line like below would not convert to utf8

```
Subject: =?MS949?B?W7+luuq3ucDOXQ==?=
```

Renaming the Charset string in the headers to EUC-KR allows the same base64 string to decode and represent correctly.
Change in this PR achieves two things

- pre-register well known aliases
- register a lua function which allows adding additional alias

Quick code example

```
local kumo = require 'kumo'

kumo.add_charset_alias {
  { 'euc-kr', { 'ms949', 'cp949' } },
}

local body = [[Subject: =?MS949?B?W7+luuq3ucDOXQ==?=

test]]

local msg = kumo.make_message('<>', '<>', body)
msg:import_headers {
  { name = 'Subject' },
}
local subject = msg:get_meta 'subject'
print('Subject = ', subject)
```