### PR TITLE
handle body only email

### DIFF
--- a/crates/mailparsing/src/header.rs
+++ b/crates/mailparsing/src/header.rs
@@ -81,6 +81,22 @@ pub struct HeaderParseResult<'a> {
     pub overall_conformance: MessageConformance,
 }
 
+/// Returns true if the first line of `data` is a valid header field, indicating
+/// the message has a header section. Per RFC 5322 a field name is one or more
+/// `ftext` characters (printable US-ASCII, no whitespace, excluding colon)
+/// followed by a colon, so the first line must match that to be a header.
+fn first_line_is_header(data: &[u8]) -> bool {
+    let mut saw_name = false;
+    for &b in data {
+        match b {
+            b':' => return saw_name,
+            0x21..=0x7e => saw_name = true,
+            _ => return false,
+        }
+    }
+    false
+}
+
 impl<'a> Header<'a> {
     pub fn with_name_value<N: Into<SharedString<'a>>, V: Into<SharedString<'a>>>(
         name: N,
@@ -246,6 +262,19 @@ impl<'a> Header<'a> {
         S: IntoSharedString<'a>,
     {
         let (header_block, mut overall_conformance) = header_block.into_shared_string();
+
+        // Decide whether the message has a header section at all. An RFC 5322
+        // header field has the form `field-name ":" value`, so the first line
+        // of the message must be a valid header field for there to be any
+        // headers. If it is not, then, the message has no header section and the entire content is the body.
+        if !first_line_is_header(header_block.as_bytes()) {
+            return Ok(HeaderParseResult {
+                headers: HeaderMap::new(vec![]),
+                body_offset: 0,
+                overall_conformance,
+            });
+        }
+
         let mut headers = vec![];
         let mut idx = 0;
 
@@ -265,11 +294,6 @@ impl<'a> Header<'a> {
                 }
                 return Err(MailParsingError::HeaderParse(
                     "lone CR in header".to_string(),
-                ));
-            }
-            if headers.is_empty() && b.is_ascii_whitespace() {
-                return Err(MailParsingError::HeaderParse(
-                    "header block must not start with spaces".to_string(),
                 ));
             }
             let (header, next) = Self::parse(header_block.slice(idx..header_block.len()))?;

--- a/crates/mailparsing/src/header.rs
+++ b/crates/mailparsing/src/header.rs
@@ -81,20 +81,21 @@ pub struct HeaderParseResult<'a> {
     pub overall_conformance: MessageConformance,
 }
 
-/// Returns true if the first line of `data` is a valid header field, indicating
-/// the message has a header section. Per RFC 5322 a field name is one or more
-/// `ftext` characters (printable US-ASCII, no whitespace, excluding colon)
-/// followed by a colon, so the first line must match that to be a header.
+/// Returns true if the first line of `data` is a plausible header field: a field
+/// name (`ftext`: printable US-ASCII, no whitespace, excluding colon) that is
+/// either followed by a colon or ends the line on its own (a colon-less name is
+/// tolerated). Used to tell whether the message has a header section at all.
 fn first_line_is_header(data: &[u8]) -> bool {
     let mut saw_name = false;
     for &b in data {
         match b {
             b':' => return saw_name,
+            b'\r' | b'\n' => return saw_name,
             0x21..=0x7e => saw_name = true,
             _ => return false,
         }
     }
-    false
+    saw_name
 }
 
 impl<'a> Header<'a> {

--- a/crates/mailparsing/src/mimepart.rs
+++ b/crates/mailparsing/src/mimepart.rs
@@ -1791,13 +1791,9 @@ Ok(
 
     #[test]
     fn funky_headers() {
-        // A colon-less line that is *not* the first line is still tolerated as
-        // a header with the MISSING_COLON_VALUE conformance flag. The first
-        // line must be a valid header for the message to have a header section.
         let message = concat!(
-            "Subject: hello\r\n",
-            "Other\r\n",
-            "Also:\r\n",
+            "Subject\r\n",
+            "Other:\r\n",
             "Content-Type: multipart/alternative; boundary=foobar\r\n",
             "Mime-Version: 1.0\r\n",
             "Date: Sun, 02 Oct 2016 07:06:22 -0700 (PDT)\r\n",

--- a/crates/mailparsing/src/mimepart.rs
+++ b/crates/mailparsing/src/mimepart.rs
@@ -1791,9 +1791,13 @@ Ok(
 
     #[test]
     fn funky_headers() {
+        // A colon-less line that is *not* the first line is still tolerated as
+        // a header with the MISSING_COLON_VALUE conformance flag. The first
+        // line must be a valid header for the message to have a header section.
         let message = concat!(
-            "Subject\r\n",
-            "Other:\r\n",
+            "Subject: hello\r\n",
+            "Other\r\n",
+            "Also:\r\n",
             "Content-Type: multipart/alternative; boundary=foobar\r\n",
             "Mime-Version: 1.0\r\n",
             "Date: Sun, 02 Oct 2016 07:06:22 -0700 (PDT)\r\n",
@@ -1805,6 +1809,43 @@ Ok(
         assert!(part
             .conformance()
             .contains(MessageConformance::MISSING_COLON_VALUE));
+    }
+
+    #[test]
+    fn header_less_body_starting_with_space() {
+        // The body begins with a space, which cannot start a header field, so
+        // the message has no headers and the entire content is the body.
+        let message = " test\r\n";
+        let part = MimePart::parse(message).unwrap();
+        assert!(part.headers().iter().next().is_none());
+        assert_eq!(part.raw_body(), message);
+    }
+
+    #[test]
+    fn header_less_html_body() {
+        // Raw HTML with no headers: the first line is not a valid header field
+        // (no colon), so the whole message is treated as the body rather than
+        // being rejected.
+        let message = concat!(
+            "<!DOCTYPE html>\r\n",
+            "<html lang=\"en\" xmlns:v=\"urn:schemas-microsoft-com:vml\">\r\n",
+            "<head>\r\n",
+            "    <meta charset=\"utf-8\">\r\n",
+            "\r\n",
+        );
+        let part = MimePart::parse(message).unwrap();
+        assert!(part.headers().iter().next().is_none());
+        assert_eq!(part.raw_body(), message);
+    }
+
+    #[test]
+    fn header_less_body_with_colon_sentence() {
+        // A body sentence that happens to contain a colon must not be mistaken
+        // for a header: a field name may not contain whitespace.
+        let message = "one two three: email\r\n";
+        let part = MimePart::parse(message).unwrap();
+        assert!(part.headers().iter().next().is_none());
+        assert_eq!(part.raw_body(), message);
     }
 
     /// This is a regression test for an issue where we'd interpret the


### PR DESCRIPTION
Messages which consists of no header are valid per RPC.
But kumo would throw an error when calling header operation against such message.
This is cause it is miss interpreting the body as header.  

```
kumod::smtp_server: Error in SmtpServerSession: invalid header: header cannot start with space
```

Confirm if the first line of DATA is properly structured header. 
If not, treat the message as having no header and the whole DATA is a body.