### PR TITLE
Add psl_suffix_is_known / psl_domain_is_known helpers

### DIFF
--- a/crates/mod-string/src/lib.rs
+++ b/crates/mod-string/src/lib.rs
@@ -112,10 +112,26 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
     )?;
 
     string_mod.set(
+        "psl_domain_is_known",
+        lua.create_function(move |_, s: String| {
+            let n = psl_utils::normalize_domain(&s);
+            Ok(psl_utils::domain_is_known(&n))
+        })?,
+    )?;
+
+    string_mod.set(
         "psl_suffix",
         lua.create_function(move |_, s: String| {
             let n = psl_utils::normalize_domain(&s);
             Ok(psl_utils::suffix_str(&n).map(|s| s.to_string()))
+        })?,
+    )?;
+
+    string_mod.set(
+        "psl_suffix_is_known",
+        lua.create_function(move |_, s: String| {
+            let n = psl_utils::normalize_domain(&s);
+            Ok(psl_utils::suffix_is_known(&n))
         })?,
     )?;
 

--- a/crates/psl-utils/src/lib.rs
+++ b/crates/psl-utils/src/lib.rs
@@ -27,6 +27,27 @@ pub fn suffix_str(s: &str) -> Option<&str> {
     psl::suffix_str(s)
 }
 
+/// Check whether the public suffix is explicitly present in the public
+/// suffix list (as opposed to being resolved via the fallback rule for an
+/// unknown top-level domain). Returns `false` when the input has no public
+/// suffix. The caller is expected to pass an already-normalized domain
+/// (typically via [`normalize_domain`]).
+pub fn suffix_is_known(s: &str) -> bool {
+    psl::suffix(s.as_bytes())
+        .map(|suffix| suffix.is_known())
+        .unwrap_or(false)
+}
+
+/// Check whether the registrable domain's public suffix is explicitly
+/// present in the public suffix list. Returns `false` when the input has no
+/// registrable domain. The caller is expected to pass an already-normalized
+/// domain (typically via [`normalize_domain`]).
+pub fn domain_is_known(s: &str) -> bool {
+    psl::domain(s.as_bytes())
+        .map(|domain| domain.suffix().is_known())
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,5 +89,41 @@ mod tests {
     fn domain_str_after_normalize() {
         let n = normalize_domain("foo.Example.COM.");
         assert_eq!(domain_str(&n), Some("example.com"));
+    }
+
+    #[test]
+    fn suffix_is_known_known() {
+        let n = normalize_domain("www.example.com");
+        assert_eq!(suffix_is_known(&n), true);
+    }
+
+    #[test]
+    fn suffix_is_known_unknown_fallback() {
+        let n = normalize_domain("domain.invalid");
+        assert_eq!(suffix_is_known(&n), false);
+    }
+
+    #[test]
+    fn suffix_is_known_empty() {
+        let n = normalize_domain("");
+        assert_eq!(suffix_is_known(&n), false);
+    }
+
+    #[test]
+    fn domain_is_known_known() {
+        let n = normalize_domain("www.example.com");
+        assert_eq!(domain_is_known(&n), true);
+    }
+
+    #[test]
+    fn domain_is_known_unknown_fallback() {
+        let n = normalize_domain("domain.invalid");
+        assert_eq!(domain_is_known(&n), false);
+    }
+
+    #[test]
+    fn domain_is_known_empty() {
+        let n = normalize_domain("");
+        assert_eq!(domain_is_known(&n), false);
     }
 }

--- a/docs/reference/string/psl_domain_is_known.md
+++ b/docs/reference/string/psl_domain_is_known.md
@@ -1,0 +1,21 @@
+# kumo.string.psl_domain_is_known
+
+```lua
+kumo.string.psl_domain_is_known(STRING)
+```
+
+{{since('TBD')}}
+
+Check whether the registrable domain's public suffix is explicitly listed in
+Mozilla's [Public Suffix
+List](https://publicsuffix.org/).
+
+Returns `true` when the input is a registrable domain whose public suffix is
+explicitly listed, or `false` when the suffix was derived from an unlisted
+label, or when the input has no registrable domain.
+
+```lua
+assert(kumo.string.psl_domain_is_known 'www.example.com' == true)
+assert(kumo.string.psl_domain_is_known 'domain.invalid' == false)
+assert(kumo.string.psl_domain_is_known 'com' == false)
+```

--- a/docs/reference/string/psl_suffix_is_known.md
+++ b/docs/reference/string/psl_suffix_is_known.md
@@ -1,0 +1,18 @@
+# kumo.string.psl_suffix_is_known
+
+```lua
+kumo.string.psl_suffix_is_known(STRING)
+```
+
+{{since('TBD')}}
+
+Check whether the public suffix is explicitly listed in Mozilla's [Public Suffix
+List](https://publicsuffix.org/).
+
+Returns `true` when the suffix is explicitly listed, or `false` when the suffix
+was derived from an unlisted label, or when the input has no public suffix.
+
+```lua
+assert(kumo.string.psl_suffix_is_known 'www.example.com' == true)
+assert(kumo.string.psl_suffix_is_known 'domain.invalid' == false)
+```


### PR DESCRIPTION
Adding kumo.string.psl_suffix_is_known and kumo.string.psl_domain_is_known, which report whether the resolved public suffix is explicitly listed in Mozilla's [Public Suffix List](https://publicsuffix.org/list).

The psl crate applies a "fallback rule": a domain whose public suffix is not in the list (e.g. `domain.invalid`) still resolves to a suffix, but that suffix is not explicitly known. Existing kumo.string.psl_suffix / psl_domain discard this information, so fallback-resolved suffixes are indistinguishable from explicitly listed ones.

The new functions return `true` when the suffix is explicitly listed, or `false` otherwise (fallback-resolved, or no public suffix at all).